### PR TITLE
imp(crud): Keep comments at head of changelog file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!--
+This changelog was created using the `clu` binary
+(https://github.com/MalteHerrmann/changelog-utils).
+-->
 # Changelog
 
 ## Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,5 @@ This changelog was created using the `clu` binary
 
 ### Improvements
 
+- (crud) [#14](https://github.com/MalteHerrmann/changelog-utils/pull/14) Keep comments at head of file.
 - (lint) [#6](https://github.com/MalteHerrmann/changelog-utils/pull/6) Remove Python implementation.


### PR DESCRIPTION
This PR implements the necessary `comments` field for the `Changelog` struct in order to keep the comments at the head of the changelog file.
