### PR TITLE
imp(ci): Add changelog linter as CI action

### DIFF
--- a/.github/workflows/changelog-lint.yaml
+++ b/.github/workflows/changelog-lint.yaml
@@ -1,0 +1,15 @@
+name: Changelog Linter
+
+on:
+  pull_request:
+
+jobs:
+  lint-changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out the repository
+      uses: actions/checkout@v4
+
+    - name: Run changelog linter
+      uses: MalteHerrmann/changelog-lint-action@0918ef12e6dc06adce0743e1c6c13707a7c20323

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog was created using the `clu` binary
 
 ### Improvements
 
+- (ci) [#36](https://github.com/MalteHerrmann/changelog-utils/pull/36) Add changelog linter as CI action.
 - (crud) [#31](https://github.com/MalteHerrmann/changelog-utils/pull/31) Prefill input to add an entry with pull request information.
 - (ci) [#30](https://github.com/MalteHerrmann/changelog-utils/pull/30) Add changelog diff check to CI actions.
 - (all) [#28](https://github.com/MalteHerrmann/changelog-utils/pull/28) Update Cargo manifest with more information and updated version.


### PR DESCRIPTION
This PR adds the changelog linter action that is based on this repository to the running CI workflows.
