### PR TITLE
fix(crud): Keep legacy contents during export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ This changelog was created using the `clu` binary
 - (config) [#27](https://github.com/MalteHerrmann/changelog-utils/pull/27) Adjust configuration to have sorted entries.
 - (all) [#26](https://github.com/MalteHerrmann/changelog-utils/pull/26) Add clippy and address linter warnings.
 
+### Bug Fixes
+
+- (crud) [#38](https://github.com/MalteHerrmann/changelog-utils/pull/38) Keep legacy contents during export.
+
 ## [v1.0.0](https://github.com/MalteHerrmann/changelog-utils/releases/tag/v1.0.0) - 2024-06-15
 
 ### Features

--- a/tests/testdata/changelog_fixed.md
+++ b/tests/testdata/changelog_fixed.md
@@ -37,3 +37,7 @@ Some comments at head of file...
 - (vesting) [#1862](https://github.com/evmos/evmos/pull/1862) Add Authorization Grants to the Vesting extension.
 - (app) [#555](https://github.com/evmos/evmos/pull/555) `v4.0.0` upgrade logic.
 
+## [v2.0.0](https://github.com/evmos/evmos/releases/tag/v2.0.0) - 2021-10-31
+### State Machine Breaking
+
+- legacy entries do not have to be fully correct

--- a/tests/testdata/changelog_to_be_fixed.md
+++ b/tests/testdata/changelog_to_be_fixed.md
@@ -37,3 +37,7 @@ Some comments at head of file...
 - (vesting) [#1862](https://github.com/evmos/evmos/pull/1862) Add Authorization Grants to the Vesting extension.
 - (app) [#555](https://github.com/evmos/evmos/pull/555) `v4.0.0` upgrade logic.
 
+## [v2.0.0](https://github.com/evmos/evmos/releases/tag/v2.0.0) - 2021-10-31
+### State Machine Breaking
+
+- legacy entries do not have to be fully correct


### PR DESCRIPTION
This PR implements the logic to keep the legacy contents when exporting the changelog based on the parsed information.
Previously, this was cutting the legacy contents because they were not tracked as they were ignored during parsing.
