### PR TITLE
imp(config): Add Git origin to initialized configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog was created using the `clu` binary
 
 ### Improvements
 
+- (config) [#41](https://github.com/MalteHerrmann/changelog-utils/pull/41) Add Git origin to initialized configuration.
 - (ci) [#36](https://github.com/MalteHerrmann/changelog-utils/pull/36) Add changelog linter as CI action.
 - (crud) [#31](https://github.com/MalteHerrmann/changelog-utils/pull/31) Prefill input to add an entry with pull request information.
 - (ci) [#30](https://github.com/MalteHerrmann/changelog-utils/pull/30) Add changelog diff check to CI actions.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -112,6 +112,8 @@ pub enum GitHubError {
     Origin,
     #[error("failed to decode output: {0}")]
     OutputDecoding(#[from] FromUtf8Error),
+    #[error("failed to match GitHub repo: {0}")]
+    RegexMatch(String),
     #[error("failed to execute command: {0}")]
     StdCommand(#[from] io::Error),
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -54,6 +54,10 @@ pub enum InitError {
     FailedToWrite(#[from] io::Error),
     #[error("config already created")]
     ConfigAlreadyFound,
+    #[error("error exporting config: {0}")]
+    ConfigError(#[from] ConfigError),
+    #[error("failed to get origin")]
+    OriginError(#[from] GitHubError),
 }
 
 #[derive(Error, Debug)]
@@ -104,6 +108,8 @@ pub enum GitHubError {
     NoGitHubRepo,
     #[error("no pull request open for branch")]
     NoOpenPR,
+    #[error("failed to get origin")]
+    Origin,
     #[error("failed to decode output: {0}")]
     OutputDecoding(#[from] FromUtf8Error),
     #[error("failed to execute command: {0}")]

--- a/src/github.rs
+++ b/src/github.rs
@@ -107,10 +107,13 @@ pub fn get_origin() -> Result<String, GitHubError> {
 
     match output.status.success() {
         true => {
-            Ok(String::from_utf8(output.stdout)?
+            let origin = String::from_utf8(output.stdout)?;
+            Ok(origin
                 .trim() // Trim whitespace from end of output
                 .strip_suffix(".git")
-                .expect("expected .git suffix in remote repository")
+                .expect(
+                    format!("expected .git suffix in remote repository; got: {}", origin).as_str(),
+                )
                 .to_string())
         }
         false => Err(GitHubError::Origin),

--- a/src/init.rs
+++ b/src/init.rs
@@ -20,15 +20,15 @@ pub fn init_in_folder(target: PathBuf) -> Result<(), InitError> {
     let mut config = create_default_config();
 
     if let Ok(origin) = get_origin() {
-        config.target_repo = origin.clone();
+        config.target_repo.clone_from(&origin);
         println!("configured target repository: {}", origin);
     };
 
-    if let Ok(_) = fs::read_to_string(&config_path) {
+    if fs::read_to_string(&config_path).is_ok() {
         return Err(InitError::ConfigAlreadyFound);
     };
 
-    Ok(config.export(&config_path.as_path())?)
+    Ok(config.export(config_path.as_path())?)
 }
 
 /// Creates a new default configuration file for the tool.

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,5 +1,4 @@
-use crate::{config::Config, errors::InitError};
-use serde_json::to_string_pretty;
+use crate::{config::Config, errors::InitError, github::get_origin};
 use std::{collections::BTreeMap, fs, path::PathBuf};
 
 /// Runs the logic to initialize the changelog utilities
@@ -18,28 +17,34 @@ pub fn init_in_folder(target: PathBuf) -> Result<(), InitError> {
     }
 
     let config_path = target.join(".clconfig.json");
-    match fs::read_to_string(config_path.clone()) {
-        Ok(_) => Err(InitError::ConfigAlreadyFound),
-        Err(_) => Ok(fs::write(config_path.as_path(), create_default_config())?),
-    }
+    let mut config = create_default_config();
+
+    if let Ok(origin) = get_origin() {
+        config.target_repo = origin.clone();
+        println!("configured target repository: {}", origin);
+    };
+
+    if let Ok(_) = fs::read_to_string(&config_path) {
+        return Err(InitError::ConfigAlreadyFound);
+    };
+
+    Ok(config.export(&config_path.as_path())?)
 }
 
 /// Creates a new default configuration file for the tool.
-fn create_default_config() -> String {
+fn create_default_config() -> Config {
     let mut default_change_types: BTreeMap<String, String> = BTreeMap::new();
     default_change_types.insert("Bug Fixes".into(), "bug\\s*fixes".into());
     default_change_types.insert("Features".into(), "features".into());
     default_change_types.insert("Improvements".into(), "improvements".into());
 
-    let default_config = Config {
+    Config {
         categories: Vec::new(),
         change_types: default_change_types,
         expected_spellings: BTreeMap::new(),
         legacy_version: None,
         target_repo: "".to_string(),
-    };
-
-    to_string_pretty(&default_config).expect("failed to print default configuration")
+    }
 }
 
 /// Creates an empty skeleton for a changelog.


### PR DESCRIPTION
This PR adds the necessary logic to check for the Git origin in the current working directory when initializing the tool using `clu init`.
