### PR TITLE
feat(lint): Add support for linter escapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This changelog was created using the `clu` binary
 -->
 # Changelog
 
+## Unreleased
+
+### Features
+
+- (lint) [#46](https://github.com/MalteHerrmann/changelog-utils/pull/46) Add support for linter escapes.
+
 ## [v1.1.2](https://github.com/MalteHerrmann/changelog-utils/releases/tag/v1.1.2) - 2024-06-30
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -24,10 +24,9 @@ docker pull ghcr.io/malteherrmann/changelog-utils:[TAG]
 
 ## Usage
 
-The available subcommands can be listed when running
+The available subcommands can be listed when running `clu help`:
 
-```bash
- $ clu --help
+```yaml
 Usage: clu <COMMAND>
 
 Commands:
@@ -58,7 +57,7 @@ in existing projects. In that case, it will only create the default configuratio
 You can add or remove configurations as you like with the
 corresponding subcommands of `clu config`.
 
-```bash
+```yaml
 Usage: clu config <COMMAND>
 
 Commands:
@@ -73,3 +72,19 @@ Commands:
 Options:
   -h, --help  Print help
 ```
+
+## Linter Escape Patterns
+
+The linter can be escaped for a given line or just for specific sublinters.
+To keep a consistent changelog structure we only allow for escapes to be effective for
+individual PR changes instead of release (e.g. `## [v0.1.0](...)`) or change type lines (e.g. `### Bug Fixes`).
+
+The following escape patterns are available:
+
+| Escape Pattern | Description |
+|----------------------------------------------------------|---------------------------------------|
+| `<!-- clu-disable-next-line -->` | Escapes any checks for the next line. |
+| `<!-- clu-disable-next-line-duplicate-pr` | Escapes a potential duplicate PR warning in the next line. This applies especially for backported changes that occur in multiple releases. |
+
+All available escape patterns can be appended by an optional description that is separated by a colon,
+e.g. `<!-- clu-disable-next-line-duplicate-pr: known duplicate (backported PR) -->`.

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -35,7 +35,10 @@ impl Entry {
     }
 }
 
-pub fn parse(config: &config::Config, line: &str) -> Result<Entry, EntryError> {
+pub fn parse(
+    config: &config::Config,
+    line: &str,
+) -> Result<Entry, EntryError> {
     let entry_pattern = Regex::new(concat!(
         r"^(?P<ws0>\s*)-(?P<ws1>\s*)\((?P<category>[a-zA-Z0-9\-]+)\)",
         r"(?P<ws2>\s*)\[(?P<bs>\\)?#(?P<pr>\d+)]",
@@ -49,8 +52,6 @@ pub fn parse(config: &config::Config, line: &str) -> Result<Entry, EntryError> {
     };
 
     // NOTE: calling unwrap here is okay because we checked that the pattern matched above
-    //
-    // TODO: This should definitely improved if possible, using some iterator stuff maybe?
     let category = matches.name("category").unwrap().as_str();
     let description = matches.name("desc").unwrap().as_str();
     let link = matches.name("link").unwrap().as_str();

--- a/src/escapes.rs
+++ b/src/escapes.rs
@@ -1,0 +1,50 @@
+use regex::Regex;
+
+/// Enum for the available linter escapes.
+#[derive(Debug, PartialEq)]
+pub enum LinterEscape {
+    FullLine,
+    DuplicatePR,
+}
+
+/// Checks the given comment for an escape pattern.
+pub fn check_escape_pattern(line: &str) -> Option<LinterEscape> {
+    // TODO: improve handling here with associated traits for the linter escapes?
+    match Regex::new(r"<!--\s*clu-disable-next-line-duplicate-pr(:.+)?\s*-->").unwrap().is_match(line) {
+        true => Some(LinterEscape::DuplicatePR),
+        false => match Regex::new(r"<!--\s*clu-disable-next-line(:.+)?\s*-->").unwrap().is_match(line) {
+            true => Some(LinterEscape::FullLine),
+            false => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod escape_tests {
+    use super::*;
+
+    #[test]
+    fn test_no_escape() {
+        assert!(check_escape_pattern("line without escape pattern").is_none());
+    }
+
+    #[test]
+    fn test_escape_full_line() {
+        assert_eq!(check_escape_pattern("<!-- clu-disable-next-line -->"), Some(LinterEscape::FullLine));
+    }
+
+    #[test]
+    fn test_escape_full_line_with_comment() {
+        assert_eq!(check_escape_pattern("<!-- clu-disable-next-line: optional description -->"), Some(LinterEscape::FullLine));
+    }
+
+    #[test]
+    fn test_escape_duplicate() {
+        assert_eq!(check_escape_pattern("<!-- clu-disable-next-line-duplicate-pr -->"), Some(LinterEscape::DuplicatePR));
+    }
+
+    #[test]
+    fn test_escape_duplicate_with_comment() {
+        assert_eq!(check_escape_pattern("<!-- clu-disable-next-line-duplicate-pr: optional description -->"), Some(LinterEscape::DuplicatePR));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod cli_config;
 pub mod config;
 mod entry;
 pub mod errors;
+mod escapes;
 pub mod github;
 pub mod init;
 pub mod lint;

--- a/tests/init_test.rs
+++ b/tests/init_test.rs
@@ -1,12 +1,11 @@
 use assert_fs::{prelude::*, TempDir};
+use clu::errors::InitError;
 use clu::init;
 use predicates::prelude::*;
-use clu::errors::InitError;
 
 #[test]
 fn test_init_empty_folder() {
-    let temp_dir = TempDir::new()
-        .expect("failed to create temporary directory");
+    let temp_dir = TempDir::new().expect("failed to create temporary directory");
 
     assert!(
         init::init_in_folder(temp_dir.path().to_path_buf()).is_ok(),
@@ -24,8 +23,7 @@ fn test_init_empty_folder() {
 
 #[test]
 fn test_init_changelog_exists() {
-    let temp_dir = TempDir::new()
-        .expect("failed to create temporary directory");
+    let temp_dir = TempDir::new().expect("failed to create temporary directory");
 
     temp_dir
         .child("CHANGELOG.md")
@@ -44,12 +42,10 @@ fn test_init_changelog_exists() {
     temp_dir
         .child(".clconfig.json")
         .assert(predicate::path::exists());
-
 }
 #[test]
 fn test_init_changelog_and_config_exists() {
-    let temp_dir = TempDir::new()
-        .expect("failed to create temporary directory");
+    let temp_dir = TempDir::new().expect("failed to create temporary directory");
 
     temp_dir
         .child("CHANGELOG.md")
@@ -62,6 +58,12 @@ fn test_init_changelog_and_config_exists() {
         .expect("failed to create dummy config");
 
     let res = init::init_in_folder(temp_dir.path().to_path_buf());
-    assert!(res.is_err(), "expected failure trying to initialize with config already existing");
-    assert_eq!(res.unwrap_err().to_string(), InitError::ConfigAlreadyFound.to_string())
+    assert!(
+        res.is_err(),
+        "expected failure trying to initialize with config already existing"
+    );
+    assert_eq!(
+        res.unwrap_err().to_string(),
+        InitError::ConfigAlreadyFound.to_string()
+    )
 }

--- a/tests/lint_test.rs
+++ b/tests/lint_test.rs
@@ -35,10 +35,9 @@ fn it_should_pass_for_incorrect_changelogs_that_has_no_critical_flaws() {
             "tests/testdata/changelog_fail.md:25: PR description should end with a dot: 'Fixed the problem `gas_used` is 0'",
             "tests/testdata/changelog_fail.md:27: 'Invalid Category' is not a valid change type",
             "tests/testdata/changelog_fail.md:31: duplicate change type in release Unreleased: Bug Fixes",
-            "tests/testdata/changelog_fail.md:40: duplicate PR: #1801",
-            "tests/testdata/changelog_fail.md:42: duplicate release: v15.0.0",
-            "tests/testdata/changelog_fail.md:46: duplicate PR: #1862",
-            "tests/testdata/changelog_fail.md:47: invalid entry: - malformed entry in changelog",
+            "tests/testdata/changelog_fail.md:43: duplicate release: v15.0.0",
+            "tests/testdata/changelog_fail.md:47: duplicate PR: #1862",
+            "tests/testdata/changelog_fail.md:50: invalid entry: - another malformed entry in changelog",
         ]
     );
 }

--- a/tests/testdata/changelog_fail.md
+++ b/tests/testdata/changelog_fail.md
@@ -37,6 +37,7 @@ Some comments at head of file...
 ### API Breaking
 
 - (vesting) [#1862](https://github.com/evmos/evmos/pull/1862) Add Authorization Grants to the Vesting extension.
+<!-- clu-disable-next-line-duplicate-pr: known duplicate (backport) -->
 - (evm) [#1801](https://github.com/evmos/evmos/pull/1801) Fixed the problem `gas_used` is 0.
 
 ## [v15.0.0](https://github.com/evmos/evmos/releases/tag/v15.0.0) - 2023-10-31
@@ -44,4 +45,6 @@ Some comments at head of file...
 ### API Breaking
 
 - (vesting) [#1862](https://github.com/evmos/evmos/pull/1862) Add Authorization Grants to the Vesting extension.
+<!-- clu-disable-next-line: malformed line is okay here -->
 - malformed entry in changelog
+- another malformed entry in changelog


### PR DESCRIPTION
This PR adds the logic for escape patterns. As a first step, there are two support escape patterns:

- `clu-disable-next-line`
- `clu-disable-next-line-duplicate-pr`

----

Closes #39
