### PR TITLE
imp(config): Get available configuration from existing changelog during initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This changelog was created using the `clu` binary
 
 - (lint) [#46](https://github.com/MalteHerrmann/changelog-utils/pull/46) Add support for linter escapes.
 
+### Improvements
+
+- (config) [#51](https://github.com/MalteHerrmann/changelog-utils/pull/51) Get available configuration from existing changelog during initialization.
+
 ## [v1.1.2](https://github.com/MalteHerrmann/changelog-utils/releases/tag/v1.1.2) - 2024-06-30
 
 ### Bug Fixes

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -35,10 +35,7 @@ impl Entry {
     }
 }
 
-pub fn parse(
-    config: &config::Config,
-    line: &str,
-) -> Result<Entry, EntryError> {
+pub fn parse(config: &config::Config, line: &str) -> Result<Entry, EntryError> {
     let entry_pattern = Regex::new(concat!(
         r"^(?P<ws0>\s*)-(?P<ws1>\s*)\((?P<category>[a-zA-Z0-9\-]+)\)",
         r"(?P<ws2>\s*)\[(?P<bs>\\)?#(?P<pr>\d+)]",

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -7,6 +7,8 @@ use regex::{Error, Regex, RegexBuilder};
 /// Represents an individual entry in the changelog.
 #[derive(Clone, Debug)]
 pub struct Entry {
+    /// The category of the entry
+    pub category: String,
     /// The fixed line adhering to all standards.
     pub fixed: String,
     /// The PR number for the given change.
@@ -28,6 +30,7 @@ impl Entry {
         let fixed = build_fixed(category, link.as_str(), description, pr_number);
 
         Entry {
+            category: category.to_string(),
             fixed,
             pr_number,
             problems: Vec::new(),
@@ -88,6 +91,7 @@ pub fn parse(config: &config::Config, line: &str) -> Result<Entry, EntryError> {
     );
 
     Ok(Entry {
+        category: fixed_category.to_string(),
         fixed, // TODO: why is it not possible to have this as &'a str too?
         pr_number,
         problems,

--- a/src/escapes.rs
+++ b/src/escapes.rs
@@ -10,12 +10,18 @@ pub enum LinterEscape {
 /// Checks the given comment for an escape pattern.
 pub fn check_escape_pattern(line: &str) -> Option<LinterEscape> {
     // TODO: improve handling here with associated traits for the linter escapes?
-    match Regex::new(r"<!--\s*clu-disable-next-line-duplicate-pr(:.+)?\s*-->").unwrap().is_match(line) {
+    match Regex::new(r"<!--\s*clu-disable-next-line-duplicate-pr(:.+)?\s*-->")
+        .unwrap()
+        .is_match(line)
+    {
         true => Some(LinterEscape::DuplicatePR),
-        false => match Regex::new(r"<!--\s*clu-disable-next-line(:.+)?\s*-->").unwrap().is_match(line) {
+        false => match Regex::new(r"<!--\s*clu-disable-next-line(:.+)?\s*-->")
+            .unwrap()
+            .is_match(line)
+        {
             true => Some(LinterEscape::FullLine),
             false => None,
-        }
+        },
     }
 }
 
@@ -30,21 +36,35 @@ mod escape_tests {
 
     #[test]
     fn test_escape_full_line() {
-        assert_eq!(check_escape_pattern("<!-- clu-disable-next-line -->"), Some(LinterEscape::FullLine));
+        assert_eq!(
+            check_escape_pattern("<!-- clu-disable-next-line -->"),
+            Some(LinterEscape::FullLine)
+        );
     }
 
     #[test]
     fn test_escape_full_line_with_comment() {
-        assert_eq!(check_escape_pattern("<!-- clu-disable-next-line: optional description -->"), Some(LinterEscape::FullLine));
+        assert_eq!(
+            check_escape_pattern("<!-- clu-disable-next-line: optional description -->"),
+            Some(LinterEscape::FullLine)
+        );
     }
 
     #[test]
     fn test_escape_duplicate() {
-        assert_eq!(check_escape_pattern("<!-- clu-disable-next-line-duplicate-pr -->"), Some(LinterEscape::DuplicatePR));
+        assert_eq!(
+            check_escape_pattern("<!-- clu-disable-next-line-duplicate-pr -->"),
+            Some(LinterEscape::DuplicatePR)
+        );
     }
 
     #[test]
     fn test_escape_duplicate_with_comment() {
-        assert_eq!(check_escape_pattern("<!-- clu-disable-next-line-duplicate-pr: optional description -->"), Some(LinterEscape::DuplicatePR));
+        assert_eq!(
+            check_escape_pattern(
+                "<!-- clu-disable-next-line-duplicate-pr: optional description -->"
+            ),
+            Some(LinterEscape::DuplicatePR)
+        );
     }
 }

--- a/tests/init_test.rs
+++ b/tests/init_test.rs
@@ -1,7 +1,7 @@
 use assert_fs::{prelude::*, TempDir};
 use clu::{config, errors::InitError, init};
 use predicates::prelude::*;
-use std::fs;
+use std::{collections::BTreeMap, fs};
 
 #[test]
 fn test_init_empty_folder() {
@@ -32,7 +32,8 @@ fn test_init_changelog_exists() {
     assert!(fs::rename(
         temp_dir.child("changelog_fail.md"),
         temp_dir.child("CHANGELOG.md"),
-    ).is_ok());
+    )
+    .is_ok());
 
     assert!(
         init::init_in_folder(temp_dir.path().to_path_buf()).is_ok(),
@@ -54,16 +55,32 @@ fn test_init_changelog_exists() {
     )
     .expect("failed to unpack config");
 
-    assert_eq!(config.categories, vec![
-        "p256-precompile".to_string(),
-        "distribution-precompile".to_string(),
-        "evm".to_string(),
-        "testnet".to_string(),
-        "stride-outpost".to_string(),
-        "ante".to_string(),
-        "inflation".to_string(),
-        "vesting".to_string(),
-    ])
+    assert_eq!(
+        config.categories,
+        vec![
+            "ante".to_string(),
+            "distribution-precompile".to_string(),
+            "evm".to_string(),
+            "inflation".to_string(),
+            "p256-precompile".to_string(),
+            "stride-outpost".to_string(),
+            "testnet".to_string(),
+            "vesting".to_string(),
+        ]
+    );
+
+    let expected_change_types: BTreeMap<String, String> = BTreeMap::from([
+        ("Improvements".into(), "improvements".into()),
+        ("Bug Fixes".into(), "bug\\s*fixes".into()),
+        ("API Breaking".into(), "api\\s*breaking".into()),
+        (
+            "State Machine Breaking".into(),
+            "state\\s*machine\\s*breaking".into(),
+        ),
+        ("Invalid Category".into(), "invalid\\s*category".into()),
+    ]);
+
+    assert_eq!(config.change_types, expected_change_types);
 }
 
 #[test]


### PR DESCRIPTION
- **add wip and formatter**
- **get config settings from existing changelog**

This PR adds the necessary logic to parse an existing changelog and try to find available change types and categories from the given changelog.
