### PR TITLE
fix(crud): Use abbreviations from config to derive change type from PR info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ This changelog was created using the `clu` binary
 - (crud) [#48](https://github.com/MalteHerrmann/changelog-utils/pull/48) Use authenticated requests when checking open PRs.
 - (config) [#51](https://github.com/MalteHerrmann/changelog-utils/pull/51) Get available configuration from existing changelog during initialization.
 
+### Bug Fixes
+
+- (crud) [#58](https://github.com/MalteHerrmann/changelog-utils/pull/58) Use abbreviations from config to derive change type from PR info.
+
 ## [v1.1.2](https://github.com/MalteHerrmann/changelog-utils/releases/tag/v1.1.2) - 2024-06-30
 
 ### Bug Fixes

--- a/src/github.rs
+++ b/src/github.rs
@@ -34,7 +34,7 @@ pub fn extract_pr_info(config: &Config, pr: &PullRequest) -> Result<PRInfo, GitH
                 .iter()
                 .find(|&(_, abbrev)| abbrev.eq(ct.into()))
             {
-                change_type = name.to_owned();
+                change_type.clone_from(name);
             }
         };
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -28,13 +28,13 @@ pub fn extract_pr_info(config: &Config, pr: &PullRequest) -> Result<PRInfo, GitH
         .build()?
         .captures(pr_title.as_str())
     {
-        // TODO: adjust to reflect logic from PR #55
         if let Some(ct) = i.name("ct") {
-            match ct.as_str() {
-                "fix" => change_type = "Bug Fixes".to_string(),
-                "imp" => change_type = "Improvements".to_string(),
-                "feat" => change_type = "Features".to_string(),
-                _ => (),
+            if let Some((name, _)) = config
+                .change_types
+                .iter()
+                .find(|&(_, abbrev)| abbrev.eq(ct.into()))
+            {
+                change_type = name.to_owned();
             }
         };
 

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -40,7 +40,7 @@ pub fn get_description(default_value: &str) -> Result<String, InputError> {
 
 pub fn get_pr_description() -> Result<String, InputError> {
     Ok(
-        Editor::new("Please provide the Pull Request body with a description of the made changes.")
+        Editor::new("Please provide the Pull Request body with a description of the made changes.\n")
             .prompt()?,
     )
 }

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -39,10 +39,10 @@ pub fn get_description(default_value: &str) -> Result<String, InputError> {
 }
 
 pub fn get_pr_description() -> Result<String, InputError> {
-    Ok(
-        Editor::new("Please provide the Pull Request body with a description of the made changes.\n")
-            .prompt()?,
+    Ok(Editor::new(
+        "Please provide the Pull Request body with a description of the made changes.\n",
     )
+    .prompt()?)
 }
 
 pub fn get_target_branch(branches_page: Page<Branch>) -> Result<String, InputError> {


### PR DESCRIPTION
This PR adjusts the logic that derives the change type to use when adding a changelog entry using `clu add`, when getting the information for an open PR from GitHub.
Previously this was hardcoded but #55 changed the configuration to hold the possible abbreviations for the different change types.