### PR TITLE
imp(ci): Bump changelog linter to v0.2.1

### DIFF
--- a/.github/workflows/changelog-lint.yaml
+++ b/.github/workflows/changelog-lint.yaml
@@ -12,4 +12,4 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Run changelog linter
-      uses: MalteHerrmann/changelog-lint-action@v0.2.0
+      uses: MalteHerrmann/changelog-lint-action@v0.2.1

--- a/.github/workflows/changelog-lint.yaml
+++ b/.github/workflows/changelog-lint.yaml
@@ -12,4 +12,4 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Run changelog linter
-      uses: MalteHerrmann/changelog-lint-action@0918ef12e6dc06adce0743e1c6c13707a7c20323
+      uses: MalteHerrmann/changelog-lint-action@v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This changelog was created using the `clu` binary
 -->
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- (ci) [#60](https://github.com/MalteHerrmann/changelog-utils/pull/60) Bump changelog linter to v0.2.0.
+
 ## [v1.2.0](https://github.com/MalteHerrmann/changelog-utils/releases/tag/v1.2.0) - 2024-08-03
 
 ### Features


### PR DESCRIPTION
This PR upgrades the `clu` linter version used in the CI action to v0.2.1.