### PR TITLE
feat(cli): Enable switching between release types when not specifying a version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This changelog was created using the `clu` binary
 
 - (lint) [#61](https://github.com/MalteHerrmann/changelog-utils/pull/61) Fix version comparison.
 
+### Features
+
+- (cli) [#63](https://github.com/MalteHerrmann/changelog-utils/pull/63) Enable switching between release types when not specifying a version.
+
 ## [v1.2.0](https://github.com/MalteHerrmann/changelog-utils/releases/tag/v1.2.0) - 2024-08-03
 
 ### Features

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,7 +64,7 @@ pub struct ConfigArgs {
 
 #[derive(Args, Debug)]
 pub struct ReleaseArgs {
-    pub version: String,
+    pub version: Option<String>,
 }
 
 #[derive(Debug, Subcommand)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -46,6 +46,8 @@ pub enum InputError {
     InquireError(#[from] InquireError),
     #[error("failed to parse integer: {0}")]
     ParseError(#[from] ParseIntError),
+    #[error("invalid selection")]
+    InvalidSelection,
 }
 
 #[derive(Error, Debug)]
@@ -192,6 +194,8 @@ pub enum ReleaseCLIError {
     Config(#[from] ConfigError),
     #[error("duplicate version: {0}")]
     DuplicateVersion(String),
+    #[error("input error: {0}")]
+    Input(#[from] InputError),
     #[error("failed to parse changelog: {0}")]
     InvalidChangelog(#[from] ChangelogError),
     #[error("invalid version: {0}")]

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -46,13 +46,9 @@ pub fn get_pr_description() -> Result<String, InputError> {
 }
 
 pub fn get_release_type() -> Result<ReleaseType, InputError> {
-    // TODO: currently the case of the rc is not fully handled, since it's not possible to choose for what type of release the rc is - right now we're creating an rc for the last release, but we want to be able to e.g. increment the major version plus adding the suffix rc1
-    let available_types: Vec<String> = ReleaseType::all().iter()
-        .map(|t| t.as_str().to_string())
-        .collect();
+    let available_types: Vec<&str> = ReleaseType::all().iter().map(|t| t.as_str()).collect();
 
-    let selected_type = Select::new("Select the release type:", available_types)
-        .prompt()?;
+    let selected_type = Select::new("Select the release type:", available_types).prompt()?;
 
     // Convert the selected string back to the ReleaseType enum
     for release_type in ReleaseType::all() {

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -1,4 +1,4 @@
-use crate::{config::Config, errors::InputError};
+use crate::{config::Config, errors::InputError, release_type::ReleaseType};
 use inquire::{Editor, Select, Text};
 use octocrab::{models::repos::Branch, Page};
 
@@ -45,8 +45,23 @@ pub fn get_pr_description() -> Result<String, InputError> {
     .prompt()?)
 }
 
-pub fn get_release_type() -> Result<String, InputError> {
-    Ok("not implemented".to_string())
+pub fn get_release_type() -> Result<ReleaseType, InputError> {
+    // TODO: currently the case of the rc is not fully handled, since it's not possible to choose for what type of release the rc is - right now we're creating an rc for the last release, but we want to be able to e.g. increment the major version plus adding the suffix rc1
+    let available_types: Vec<String> = ReleaseType::all().iter()
+        .map(|t| t.as_str().to_string())
+        .collect();
+
+    let selected_type = Select::new("Select the release type:", available_types)
+        .prompt()?;
+
+    // Convert the selected string back to the ReleaseType enum
+    for release_type in ReleaseType::all() {
+        if release_type.as_str() == selected_type {
+            return Ok(release_type);
+        }
+    }
+
+    Err(InputError::InvalidSelection)
 }
 
 pub fn get_target_branch(branches_page: Page<Branch>) -> Result<String, InputError> {

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -45,6 +45,10 @@ pub fn get_pr_description() -> Result<String, InputError> {
     .prompt()?)
 }
 
+pub fn get_release_type() -> Result<String, InputError> {
+    Ok("not implemented".to_string())
+}
+
 pub fn get_target_branch(branches_page: Page<Branch>) -> Result<String, InputError> {
     let mut branches = Vec::new();
     let mut start_idx: usize = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,4 +14,5 @@ mod inputs;
 pub mod lint;
 mod release;
 pub mod release_cli;
+mod release_type;
 mod version;

--- a/src/release_cli.rs
+++ b/src/release_cli.rs
@@ -1,7 +1,7 @@
 use crate::{
     changelog::{self, Changelog},
     config,
-    errors::{ReleaseCLIError, InputError},
+    errors::ReleaseCLIError,
     inputs::get_release_type,
     release::Release,
     version
@@ -15,10 +15,10 @@ pub fn run(version_option: Option<String>) -> Result<(), ReleaseCLIError> {
 
     let version = match version_option {
         Some(v) => version::parse(v.as_str())?,
-        None => get_release_version(changelog)?,
+        None => get_release_version(&changelog)?,
     };
 
-    if changelog.releases.iter().any(|x| x.version.eq(&version)) {
+    if changelog.releases.iter().any(|x| x.version.eq(&version.to_string())) {
         return Err(ReleaseCLIError::DuplicateVersion(version.to_string()));
     }
 
@@ -29,7 +29,7 @@ pub fn run(version_option: Option<String>) -> Result<(), ReleaseCLIError> {
 
     let today = Local::now();
 
-    unreleased.version.clone_from(&version);
+    unreleased.version.clone_from(&version.to_string());
     unreleased.fixed = format!(
         "## [{0}]({1}/releases/tag/{0}) - {2}",
         version,
@@ -43,20 +43,20 @@ pub fn run(version_option: Option<String>) -> Result<(), ReleaseCLIError> {
 /// Queries the user for the desired release type and then derives the required
 /// upgraded version from the existing releases.
 ///
-/// Example: If a user selects a patch release `1.2.3`,
+/// Example: If a user selects a patch release with the latest version being `1.2.3`,
 /// the released version would be `1.2.4`.
-fn get_release_version(changelog: Changelog) -> Result<version::Version, ReleaseCLIError> {
-    let mut releases: Vec<&Release> = changelog.releases.iter().filter(|x| !x.is_unreleased()).collect();
+fn get_release_version(changelog: &Changelog) -> Result<version::Version, ReleaseCLIError> {
+    let mut prior_releases: Vec<&Release> = changelog.releases.iter().filter(|x| !x.is_unreleased()).collect();
 
     // TODO: this should be done when saving the changelog
-    releases.sort_by(|a, b| a.version.cmp(&b.version));
+    prior_releases.sort_by(|a, b| a.version.cmp(&b.version));
 
-    let latest_release = releases.last().unwrap();
-    let next_version = version::parse(&latest_release.version)?;
+    let latest_release = prior_releases.last().unwrap();
+    let latest_version = version::parse(&latest_release.version)?;
 
     let release_type = get_release_type()?;
 
-    let new_version = version::bump_version(&next_version, release_type);
+    let new_version = version::bump_version(&latest_version, &release_type);
 
     Ok(new_version)
 }

--- a/src/release_cli.rs
+++ b/src/release_cli.rs
@@ -1,12 +1,22 @@
-use crate::{changelog, config, errors::ReleaseCLIError, version};
+use crate::{
+    changelog::{self, Changelog},
+    config,
+    errors::{ReleaseCLIError, InputError},
+    inputs::get_release_type,
+    release::Release,
+    version
+};
 use chrono::offset::Local;
 
 /// Creates a new release with the given version based on the given version.
-pub fn run(version: String) -> Result<(), ReleaseCLIError> {
+pub fn run(version_option: Option<String>) -> Result<(), ReleaseCLIError> {
     let config = config::load()?;
     let mut changelog = changelog::load(config.clone())?;
 
-    version::parse(version.as_str())?;
+    let version = match version_option {
+        Some(v) => version::parse(v.as_str())?,
+        None => get_release_version(changelog)?,
+    };
 
     if changelog.releases.iter().any(|x| x.version.eq(&version)) {
         return Err(ReleaseCLIError::DuplicateVersion(version.to_string()));
@@ -28,4 +38,25 @@ pub fn run(version: String) -> Result<(), ReleaseCLIError> {
     );
 
     Ok(changelog.write(&changelog.path)?)
+}
+
+/// Queries the user for the desired release type and then derives the required
+/// upgraded version from the existing releases.
+///
+/// Example: If a user selects a patch release `1.2.3`,
+/// the released version would be `1.2.4`.
+fn get_release_version(changelog: Changelog) -> Result<version::Version, ReleaseCLIError> {
+    let mut releases: Vec<&Release> = changelog.releases.iter().filter(|x| !x.is_unreleased()).collect();
+
+    // TODO: this should be done when saving the changelog
+    releases.sort_by(|a, b| a.version.cmp(&b.version));
+
+    let latest_release = releases.last().unwrap();
+    let next_version = version::parse(&latest_release.version)?;
+
+    let release_type = get_release_type()?;
+
+    let new_version = version::bump_version(&next_version, release_type);
+
+    Ok(new_version)
 }

--- a/src/release_cli.rs
+++ b/src/release_cli.rs
@@ -4,7 +4,7 @@ use crate::{
     errors::ReleaseCLIError,
     inputs::get_release_type,
     release::Release,
-    version
+    version,
 };
 use chrono::offset::Local;
 
@@ -15,10 +15,14 @@ pub fn run(version_option: Option<String>) -> Result<(), ReleaseCLIError> {
 
     let version = match version_option {
         Some(v) => version::parse(v.as_str())?,
-        None => get_release_version(&changelog)?,
+        None => get_next_release_version(&changelog)?,
     };
 
-    if changelog.releases.iter().any(|x| x.version.eq(&version.to_string())) {
+    if changelog
+        .releases
+        .iter()
+        .any(|x| x.version.eq(&version.to_string()))
+    {
         return Err(ReleaseCLIError::DuplicateVersion(version.to_string()));
     }
 
@@ -45,8 +49,12 @@ pub fn run(version_option: Option<String>) -> Result<(), ReleaseCLIError> {
 ///
 /// Example: If a user selects a patch release with the latest version being `1.2.3`,
 /// the released version would be `1.2.4`.
-fn get_release_version(changelog: &Changelog) -> Result<version::Version, ReleaseCLIError> {
-    let mut prior_releases: Vec<&Release> = changelog.releases.iter().filter(|x| !x.is_unreleased()).collect();
+fn get_next_release_version(changelog: &Changelog) -> Result<version::Version, ReleaseCLIError> {
+    let mut prior_releases: Vec<&Release> = changelog
+        .releases
+        .iter()
+        .filter(|x| !x.is_unreleased())
+        .collect();
 
     // TODO: this should be done when saving the changelog
     prior_releases.sort_by(|a, b| a.version.cmp(&b.version));

--- a/src/release_type.rs
+++ b/src/release_type.rs
@@ -1,3 +1,7 @@
+// This is solved using the Marco implementation to be able to dynamically add options to the `ReleaseType` enum
+// while also generating the corresponding function `ReleaseType::all`, which returns all options.
+//
+// TODO: check if this can be done less complicated
 macro_rules! release_type {
     ($($name:ident),*) => {
         #[derive(Debug, Clone)]

--- a/src/release_type.rs
+++ b/src/release_type.rs
@@ -20,7 +20,7 @@ macro_rules! release_type {
 }
 
 // Define the ReleaseType enum using the macro
-release_type!(MAJOR, MINOR, PATCH, RC);
+release_type!(Major, Minor, Patch, RcMajor, RcMinor, RcPatch);
 
 #[cfg(test)]
 mod tests {
@@ -28,6 +28,6 @@ mod tests {
 
     #[test]
     fn test_all() {
-        assert_eq!(ReleaseType::all().len(), 4);
+        assert_eq!(ReleaseType::all().len(), 6);
     }
 }

--- a/src/release_type.rs
+++ b/src/release_type.rs
@@ -1,0 +1,33 @@
+macro_rules! release_type {
+    ($($name:ident),*) => {
+        #[derive(Debug, Clone)]
+        pub enum ReleaseType {
+            $($name),*
+        }
+
+        impl ReleaseType {
+            pub fn all() -> Vec<ReleaseType> {
+                vec![$(ReleaseType::$name),*]
+            }
+
+            pub fn as_str(&self) -> &'static str {
+                match self {
+                    $(ReleaseType::$name => stringify!($name),)*
+                }
+            }
+        }
+    };
+}
+
+// Define the ReleaseType enum using the macro
+release_type!(MAJOR, MINOR, PATCH, RC);
+
+#[cfg(test)]
+mod tests {
+    use super::ReleaseType;
+
+    #[test]
+    fn test_all() {
+        assert_eq!(ReleaseType::all().len(), 4);
+    }
+}

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use crate::errors::VersionError;
 use regex::Regex;
 
@@ -47,6 +48,17 @@ impl Version {
     }
 }
 
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut version_string = format!("v{}.{}.{}", self.major, self.minor, self.patch);
+        match self.rc_version {
+            Some(rc) => {version_string = version_string + &format!("-rc{}", rc)},
+            None => (),
+        }
+        write!(f, version_string.as_str())
+    }
+}
+
 /// Tries to parse the given version string.
 /// Returns an instance of Version, in case a valid version is passed.
 pub fn parse(version: &str) -> Result<Version, VersionError> {
@@ -76,6 +88,33 @@ pub fn parse(version: &str) -> Result<Version, VersionError> {
         patch,
         rc_version,
     })
+}
+
+/// Represents the release type.
+pub enum ReleaseType {
+    MAJOR,
+    MINOR,
+    PATCH,
+    RC,
+}
+
+/// Increments the version based on the given release type.
+pub fn bump_version(version: &Version, release_type: &ReleaseType) -> Version {
+    let next_version = version.clone();
+    match release_type {
+        MAJOR => next_version.major += 1,
+        MINOR => next_version.minor += 1,
+        PATCH => next_version.patch += 1,
+        RC => {
+            if let Some(rc_version) = version.rc_version {
+                next_version.rc_version = Some(rc_version + 1);
+            } else {
+                next_version.rc_version = Some(1);
+            }
+        }
+    };
+
+    next_version
 }
 
 #[cfg(test)]

--- a/src/version.rs
+++ b/src/version.rs
@@ -172,52 +172,61 @@ mod version_tests {
         assert!(parse("v11.0.1rc3").is_err());
     }
 
-    #[test]
-    fn test_bump_version_major() {
-        let version = parse("v1.2.3").expect("failed to parse version");
-        let bumped = bump_version(&version, &ReleaseType::Major);
-        assert_eq!(bumped.to_string(), "v2.0.0");
+    struct VersionBumpTestcase {
+        initial: String,
+        release_type: ReleaseType,
+        expected: String,
     }
 
     #[test]
-    fn test_bump_version_minor() {
-        let version = parse("v1.2.3").expect("failed to parse version");
-        let bumped = bump_version(&version, &ReleaseType::Minor);
-        assert_eq!(bumped.to_string(), "v1.3.0");
-    }
+    fn test_version_bump() {
+        let testcases = vec![
+            VersionBumpTestcase {
+                initial: "v1.2.3".into(),
+                release_type: ReleaseType::Major,
+                expected: "v2.0.0".into(),
+            },
+            VersionBumpTestcase {
+                initial: "v1.2.3".into(),
+                release_type: ReleaseType::Minor,
+                expected: "v1.3.0".into(),
+            },
+            VersionBumpTestcase {
+                initial: "v1.2.3".into(),
+                release_type: ReleaseType::Patch,
+                expected: "v1.2.4".into(),
+            },
+            VersionBumpTestcase {
+                initial: "v1.2.3".into(),
+                release_type: ReleaseType::RcMajor,
+                expected: "v2.0.0-rc1".into(),
+            },
+            VersionBumpTestcase {
+                initial: "v1.2.3".into(),
+                release_type: ReleaseType::RcMinor,
+                expected: "v1.3.0-rc1".into(),
+            },
+            VersionBumpTestcase {
+                initial: "v1.2.3".into(),
+                release_type: ReleaseType::RcPatch,
+                expected: "v1.2.4-rc1".into(),
+            },
+            VersionBumpTestcase {
+                initial: "v1.2.3-rc1".into(),
+                release_type: ReleaseType::RcPatch,
+                expected: "v1.2.3-rc2".into(),
+            },
+        ];
 
-    #[test]
-    fn test_bump_version_patch() {
-        let version = parse("v1.2.3").expect("failed to parse version");
-        let bumped = bump_version(&version, &ReleaseType::Patch);
-        assert_eq!(bumped.to_string(), "v1.2.4");
-    }
-
-    #[test]
-    fn test_bump_version_rc_patch() {
-        let version = parse("v1.2.3").expect("failed to parse version");
-        let bumped = bump_version(&version, &ReleaseType::RcPatch);
-        assert_eq!(bumped.to_string(), "v1.2.4-rc1");
-    }
-
-    #[test]
-    fn test_bump_version_rc_patch_increment() {
-        let version = parse("v1.2.3-rc1").expect("failed to parse version");
-        let bumped = bump_version(&version, &ReleaseType::RcPatch);
-        assert_eq!(bumped.to_string(), "v1.2.3-rc2");
-    }
-
-    #[test]
-    fn test_bump_version_rc_major() {
-        let version = parse("v1.2.3").expect("failed to parse version");
-        let bumped = bump_version(&version, &ReleaseType::RcMajor);
-        assert_eq!(bumped.to_string(), "v2.0.0-rc1");
-    }
-
-    #[test]
-    fn test_bump_version_rc_minor() {
-        let version = parse("v1.2.3").expect("failed to parse version");
-        let bumped = bump_version(&version, &ReleaseType::RcMinor);
-        assert_eq!(bumped.to_string(), "v1.3.0-rc1");
+        for tc in testcases {
+            assert_eq!(
+                bump_version(
+                    &parse(tc.initial.as_str()).expect("failed to parse initial version"),
+                    &tc.release_type,
+                )
+                .to_string(),
+                tc.expected
+            )
+        }
     }
 }


### PR DESCRIPTION
This PR includes the logic to query the user for the desired release type when running `clu release`.
The available release types correspondingly increment the latest version and use the resulting version in place of the `Unreleased` section.
