### PR TITLE
imp(cli): Apply auto fixes to new entries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog was created using the `clu` binary
 
 ### Improvements
 
+- (cli) [#65](https://github.com/MalteHerrmann/changelog-utils/pull/65) Apply auto fixes to new entries.
 - (ci) [#60](https://github.com/MalteHerrmann/changelog-utils/pull/60) Bump changelog linter to v0.2.0.
 
 ### Bug Fixes

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -157,12 +157,12 @@ pub fn check_description(config: &config::Config, desc: &str) -> (String, Vec<St
         ))
     }
 
-    let last_letter = desc
+    let last_letter = fixed
         .chars()
         .last()
         .expect("no characters found in description");
     if last_letter.to_string() != '.'.to_string() {
-        fixed = desc.to_string() + ".";
+        fixed = fixed.to_string() + ".";
         problems.push(format!("PR description should end with a dot: '{}'", desc))
     }
 


### PR DESCRIPTION
This PR adds the corresponding logic to include all automated fixes when adding a new entry to the changelog.