### PR TITLE
feat(cli): Enable adding entries for previous PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This changelog was created using the `clu` binary
 
 ### Features
 
+- (cli) [#74](https://github.com/MalteHerrmann/changelog-utils/pull/74) Enable adding entries for previous PRs.
 - (config) [#70](https://github.com/MalteHerrmann/changelog-utils/pull/70) Add changelog path to the configuration.
 - (cli) [#68](https://github.com/MalteHerrmann/changelog-utils/pull/68) Commit and push changelog entry after adding.
 - (cli) [#67](https://github.com/MalteHerrmann/changelog-utils/pull/67) Add option to push branch to remote.

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,5 @@ docker-build:
 # Lint codebase
 lint:
 	cargo clippy
+
+PHONY: test build format install docker-run docker-build lint

--- a/src/add.rs
+++ b/src/add.rs
@@ -1,10 +1,39 @@
 use crate::{
     change_type, changelog, config, entry,
-    errors::AddError,
-    github::{commit, extract_pr_info, get_git_info, get_open_pr, PRInfo},
+    errors::{AddError, GitHubError},
+    github::{commit, extract_pr_info, get_git_info, get_open_pr, get_pr_by_number, PRInfo, GitInfo},
     inputs, release,
 };
 use std::borrow::BorrowMut;
+
+/// Retrieves PR information either from a specific PR number or from an open PR.
+/// If a PR number is provided but no PR is found, returns an error.
+async fn get_pr_info(config: &config::Config, git_info: &GitInfo, pr_number: Option<u16>) -> Result<(PRInfo, bool), AddError> {
+    let pr_info: PRInfo;
+
+    if let Some(pr_number) = pr_number {
+        // Try to fetch PR information using the provided PR number
+        match get_pr_by_number(git_info, pr_number).await {
+            Ok(pr) => {
+                pr_info = extract_pr_info(config, &pr)?;
+                return Ok((pr_info, true));
+            }
+            Err(_) => {
+                return Err(AddError::PRInfo(GitHubError::NoOpenPR));
+            }
+        }
+    }
+    // If no PR number was provided, try to get open PR
+    return match get_open_pr(git_info.clone()).await {
+        Ok(pr) => {
+            pr_info = extract_pr_info(config, &pr)?;
+            Ok((pr_info, true))
+        }
+        Err(_) => {
+            Ok((PRInfo::default(), false))
+        }
+    }
+}
 
 // Runs the logic to add an entry to the unreleased section of the changelog.
 //
@@ -13,10 +42,6 @@ use std::borrow::BorrowMut;
 //
 // NOTE: the changes are NOT pushed to the origin when running the `add` command.
 pub async fn run(pr_number: Option<u16>, accept: bool) -> Result<(), AddError> {
-    if let Some(pr_number) = pr_number {
-        println!("got pr number: {}", pr_number);
-    }
-
     let config = config::load()?;
     let git_info = get_git_info(&config)?;
 
@@ -24,17 +49,7 @@ pub async fn run(pr_number: Option<u16>, accept: bool) -> Result<(), AddError> {
         config.change_types.clone().into_keys().collect();
     selectable_change_types.sort();
 
-    let retrieved: bool;
-    let pr_info = match get_open_pr(git_info).await {
-        Ok(i) => {
-            retrieved = true;
-            extract_pr_info(&config, &i)?
-        }
-        Err(_) => {
-            retrieved = false;
-            PRInfo::default()
-        }
-    };
+    let (mut pr_info, retrieved) = get_pr_info(&config, &git_info, pr_number).await?;
 
     let mut selected_change_type = pr_info.change_type.clone();
     if !accept || !retrieved || !selectable_change_types.contains(&pr_info.change_type) {

--- a/src/add.rs
+++ b/src/add.rs
@@ -12,7 +12,11 @@ use std::borrow::BorrowMut;
 // to commit the changes.
 //
 // NOTE: the changes are NOT pushed to the origin when running the `add` command.
-pub async fn run(accept: bool) -> Result<(), AddError> {
+pub async fn run(pr_number: Option<u16>, accept: bool) -> Result<(), AddError> {
+    if let Some(pr_number) = pr_number {
+        println!("got pr number: {}", pr_number);
+    }
+
     let config = config::load()?;
     let git_info = get_git_info(&config)?;
 

--- a/src/add.rs
+++ b/src/add.rs
@@ -1,9 +1,7 @@
 use crate::{
     change_type, changelog, config, entry,
     errors::AddError,
-    github::{
-        commit, extract_pr_info, get_git_info, get_open_pr, get_pr_by_number, GitInfo, PRInfo,
-    },
+    github::{commit, get_git_info, get_pr_info, PRInfo},
     inputs, release,
 };
 use std::borrow::BorrowMut;
@@ -12,26 +10,6 @@ use std::collections::HashMap;
 /// Determines if user input is required based on the accept flag and whether PR info was retrieved.
 fn should_get_user_input(accept: bool, retrieved: bool) -> bool {
     !accept || !retrieved
-}
-
-/// Retrieves PR information either from a specific PR number or from an open PR.
-/// If a PR number is provided but no PR is found, returns an error.
-async fn get_pr_info(
-    config: &config::Config,
-    git_info: &GitInfo,
-    pr_number: Option<u16>,
-) -> Result<PRInfo, AddError> {
-    if let Some(pr_number) = pr_number {
-        // Try to fetch PR information using the provided PR number
-        let pr = get_pr_by_number(git_info, pr_number).await?;
-        return Ok(extract_pr_info(config, &pr)?);
-    }
-
-    // If no PR number was provided, try to get open PR
-    match get_open_pr(git_info.clone()).await {
-        Ok(pr) => Ok(extract_pr_info(config, &pr)?),
-        Err(_) => Ok(PRInfo::default()),
-    }
 }
 
 /// Handles all user input for the changelog entry, either using existing PR info or prompting for input.

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -60,7 +60,7 @@ impl Changelog {
 pub fn load(config: Config) -> Result<Changelog, ChangelogError> {
     let changelog_file = match fs::read_dir(Path::new("./"))?.find(|e| {
         e.as_ref()
-            .is_ok_and(|e| e.file_name().to_ascii_lowercase() == "changelog.md")
+            .is_ok_and(|e| e.file_name().eq_ignore_ascii_case("changelog.md"))
     }) {
         Some(f) => f.unwrap(),
         None => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,6 +29,7 @@ It creates an empty changelog skeleton if no existing changelog is found as well
 
 #[derive(Args, Debug)]
 pub struct AddArgs {
+    pub number: Option<u16>,
     #[arg(short, long)]
     pub yes: bool,
 }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -253,9 +253,8 @@ fn check_whitespace(spaces: [&str; 5]) -> Vec<String> {
 
     spaces
         .into_iter()
-        .zip(expected_whitespace.into_iter())
-        .zip(errors.into_iter())
-        .into_iter()
+        .zip(expected_whitespace)
+        .zip(errors)
         .for_each(|((got, expected), error)| {
             if (*got).ne(expected) {
                 problems.push(error.to_string())

--- a/src/github.rs
+++ b/src/github.rs
@@ -82,8 +82,7 @@ pub async fn branch_exists_on_remote(client: &Octocrab, git_info: &GitInfo) -> b
 /// Returns an option for an open PR from the current local branch in the configured target
 /// repository if it exists.
 pub async fn get_open_pr(git_info: GitInfo) -> Result<PullRequest, GitHubError> {
-    let octocrab = get_authenticated_github_client()
-        .unwrap_or_default();
+    let octocrab = get_authenticated_github_client().unwrap_or_default();
 
     let pulls = octocrab
         .pulls(git_info.owner, git_info.repo)
@@ -231,6 +230,19 @@ pub fn get_git_info(config: &Config) -> Result<GitInfo, GitHubError> {
         repo,
         branch,
     })
+}
+
+/// Returns a PR from the repository by its number.
+pub async fn get_pr_by_number(
+    git_info: &GitInfo,
+    pr_number: u16,
+) -> Result<PullRequest, GitHubError> {
+    let client = get_authenticated_github_client()?;
+    client
+        .pulls(&git_info.owner, &git_info.repo)
+        .get(pr_number as u64)
+        .await
+        .map_err(|_| GitHubError::NoOpenPR)
 }
 
 // Ignore these tests when running on CI because there won't be a local branch

--- a/src/github.rs
+++ b/src/github.rs
@@ -82,10 +82,8 @@ pub async fn branch_exists_on_remote(client: &Octocrab, git_info: &GitInfo) -> b
 /// Returns an option for an open PR from the current local branch in the configured target
 /// repository if it exists.
 pub async fn get_open_pr(git_info: GitInfo) -> Result<PullRequest, GitHubError> {
-    let octocrab = match get_authenticated_github_client() {
-        Ok(oc) => oc,
-        _ => octocrab::Octocrab::default(),
-    };
+    let octocrab = get_authenticated_github_client()
+        .unwrap_or_default();
 
     let pulls = octocrab
         .pulls(git_info.owner, git_info.repo)

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use clu::{
 #[tokio::main]
 async fn main() -> Result<(), CLIError> {
     match ChangelogCLI::parse() {
-        ChangelogCLI::Add(add_args) => Ok(add::run(add_args.yes).await?),
+        ChangelogCLI::Add(add_args) => Ok(add::run(add_args.number, add_args.yes).await?),
         ChangelogCLI::CreatePR => Ok(create_pr::run().await?),
         ChangelogCLI::Fix => Ok(lint::run(true)?),
         ChangelogCLI::Lint => Ok(lint::run(false)?),


### PR DESCRIPTION
This PR adds the logic to add previous pull requests entries to the Changelog by passing an optional PR number to the `clu add` command.