### PR TITLE
imp(cli): Improve error handling when creating a PR and only the local changelog commit fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This changelog was created using the `clu` binary
 
 - (docker) [#75](https://github.com/MalteHerrmann/changelog-utils/pull/75) Adjust required Rust version in Dockerfile.
 
+### Improvements
+
+- (cli) [#76](https://github.com/MalteHerrmann/changelog-utils/pull/76) Improve error handling when creating a PR and only the local changelog commit fails.
+
 ## [v1.3.0](https://github.com/MalteHerrmann/changelog-utils/releases/tag/v1.3.0) - 2025-03-30
 
 ### Improvements

--- a/src/add.rs
+++ b/src/add.rs
@@ -4,7 +4,6 @@ use crate::{
     github::{commit, get_git_info, get_pr_info, PRInfo},
     inputs, release,
 };
-use std::borrow::BorrowMut;
 use std::collections::HashMap;
 
 /// Determines if user input is required based on the accept flag and whether PR info was retrieved.
@@ -91,7 +90,7 @@ pub async fn run(pr_number: Option<u16>, accept: bool) -> Result<(), AddError> {
     let mut changelog = changelog::load(config.clone())?;
     add_entry(
         &config,
-        changelog.borrow_mut(),
+        &mut changelog,
         &selected_change_type,
         &cat,
         &desc,

--- a/src/create_pr.rs
+++ b/src/create_pr.rs
@@ -53,5 +53,10 @@ pub async fn run() -> Result<(), CreateError> {
     );
 
     let cm = inputs::get_commit_message(&config)?;
-    Ok(github::commit_and_push(&config, &cm)?)
+    if let Err(e) = github::commit_and_push(&config, &cm) {
+        // NOTE: we don't want to fail here since the PR was created successfully, just the commit of the changelog failed
+        println!("failed to commit and push changes: {}", e);
+    }
+
+    Ok(())
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -28,6 +28,8 @@ pub enum CLIError {
 pub enum CreateError {
     #[error("branch not found on remote: {0}")]
     BranchNotOnRemote(String),
+    #[error("changelog error: {0}")]
+    Changelog(#[from] ChangelogError),
     #[error("failed to read configuration: {0}")]
     Config(#[from] ConfigError),
     #[error("found an existing PR for this branch: {0}")]


### PR DESCRIPTION
This PR adjusts the error handling when creating a PR. After the PR creation succeeded and the local commit and pushing the changelog file fails, the output was indicating that the creation itself had failed, even though that was not the case. This was adjusted on this PR.