### PR TITLE
feat(cli): Add AI-assisted changelog generation to create PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This changelog was created using the `clu` binary
 
 - (cli) [#76](https://github.com/MalteHerrmann/changelog-utils/pull/76) Improve error handling when creating a PR and only the local changelog commit fails.
 
+### feat
+
+- (cli) [#61637](https://github.com/MalteHerrmann/changelog-utils/pull/61637) Add AI-assisted changelog generation to create PRs.
+
 ## [v1.3.0](https://github.com/MalteHerrmann/changelog-utils/releases/tag/v1.3.0) - 2025-03-30
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This changelog was created using the `clu` binary
 
 ### Features
 
-- (cli) [#61637](https://github.com/MalteHerrmann/changelog-utils/pull/61637) Add AI-assisted changelog generation to create PRs.
+- (cli) [#78](https://github.com/MalteHerrmann/changelog-utils/pull/78) Add AI-assisted changelog generation to create PRs.
 
 ## [v1.3.0](https://github.com/MalteHerrmann/changelog-utils/releases/tag/v1.3.0) - 2025-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This changelog was created using the `clu` binary
 
 - (cli) [#76](https://github.com/MalteHerrmann/changelog-utils/pull/76) Improve error handling when creating a PR and only the local changelog commit fails.
 
-### feat
+### Features
 
 - (cli) [#61637](https://github.com/MalteHerrmann/changelog-utils/pull/61637) Add AI-assisted changelog generation to create PRs.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +144,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -271,6 +299,7 @@ dependencies = [
  "octocrab",
  "predicates",
  "regex",
+ "rig-core",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -283,6 +312,16 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation"
@@ -395,6 +434,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +478,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -573,6 +642,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
 name = "globset"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +670,31 @@ dependencies = [
  "ignore",
  "walkdir",
 ]
+
+[[package]]
+name = "h2"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -651,6 +751,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -690,6 +791,22 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -892,6 +1009,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "inquire"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,6 +1035,12 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri-string"
@@ -997,6 +1130,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,6 +1175,23 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 2.11.1",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1133,10 +1299,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "openssl"
+version = "0.10.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1208,6 +1421,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "powerfmt"
@@ -1308,6 +1527,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "reqwest"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "windows-registry",
+]
+
+[[package]]
+name = "rig-core"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff893305131b471009ab11df388612beb603ed94bb12412c256fe197b7591aa6"
+dependencies = [
+ "async-stream",
+ "base64",
+ "bytes",
+ "futures",
+ "glob",
+ "mime_guess",
+ "ordered-float",
+ "reqwest",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,7 +1651,16 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.2.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1415,6 +1711,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,12 +1751,25 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.9.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags 2.9.0",
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1466,6 +1799,17 @@ name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1634,6 +1978,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -1644,6 +1991,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.9.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1786,6 +2154,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1895,6 +2273,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1947,6 +2331,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "walkdir"
@@ -2009,6 +2399,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2038,6 +2441,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2098,6 +2524,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.53.0",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2148,11 +2603,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -2168,6 +2639,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,6 +2655,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2192,10 +2675,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2210,6 +2705,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,6 +2721,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2234,6 +2741,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2244,6 +2757,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ inquire = { version = "0.7.5", features = ["editor"]}
 chrono = "0.4.38"
 tokio = { version = "1.38.0", features = ["full"] }
 octocrab = "0.44.0"
+rig-core = "0.11.0"
 
 [features]
 remote = []

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG APP_NAME
 WORKDIR /app
 
 # Install host build dependencies.
-RUN apk add --no-cache clang lld musl-dev git
+RUN apk add --no-cache clang lld musl-dev git pkgconfig openssl-dev openssl-libs-static
 
 # Build the application.
 # Leverage a cache mount to /usr/local/cargo/registry/

--- a/src/add.rs
+++ b/src/add.rs
@@ -35,12 +35,7 @@ fn get_entry_inputs(
     }
 
     if get_inputs["change_type"] {
-        let ct_idx = selectable_change_types
-            .iter()
-            .position(|ct| ct.eq(&pr_info.change_type))
-            .unwrap_or_default();
-
-        selected_change_type = inputs::get_change_type(config, ct_idx)?;
+        selected_change_type = inputs::get_change_type(config, &pr_info.change_type)?;
     }
 
     let mut pr_number = pr_info.number;
@@ -54,13 +49,7 @@ fn get_entry_inputs(
     }
 
     if get_inputs["category"] {
-        let cat_idx = config
-            .categories
-            .iter()
-            .position(|c| c.eq(&pr_info.category))
-            .unwrap_or_default();
-
-        cat = inputs::get_category(config, cat_idx)?;
+        cat = inputs::get_category(config, &pr_info.category)?;
     }
 
     let mut desc = pr_info.description.clone();

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -33,16 +33,16 @@ impl Changelog {
 
         self.releases.iter().for_each(|release| {
             exported_string.push('\n');
-            exported_string.push_str(release.fixed.as_str());
+            exported_string.push_str(&release.fixed);
             exported_string.push('\n');
 
             release.change_types.iter().for_each(|change_type| {
                 exported_string.push('\n');
-                exported_string.push_str(change_type.fixed.as_str());
+                exported_string.push_str(&change_type.fixed);
                 exported_string.push_str("\n\n");
 
                 change_type.entries.iter().for_each(|entry| {
-                    exported_string.push_str(entry.fixed.as_str());
+                    exported_string.push_str(&entry.fixed);
                     exported_string.push('\n');
                 });
             });
@@ -370,7 +370,7 @@ pub fn get_settings_from_existing_changelog(config: &mut Config, contents: &str)
     seen_change_types.into_iter().for_each(|ct| {
         let pattern = regex::Regex::new(r"\s+")
             .unwrap()
-            .replace_all(ct.as_str(), "\\s*")
+            .replace_all(&ct, "\\s*")
             .to_ascii_lowercase();
         change_types.insert(ct, pattern);
     });

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,6 +32,8 @@ pub struct AddArgs {
     pub number: Option<u16>,
     #[arg(short, long)]
     pub yes: bool,
+    #[arg(long)]
+    pub ai: bool,
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,8 +32,6 @@ pub struct AddArgs {
     pub number: Option<u16>,
     #[arg(short, long)]
     pub yes: bool,
-    #[arg(long)]
-    pub ai: bool,
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/create_pr.rs
+++ b/src/create_pr.rs
@@ -1,4 +1,4 @@
-use crate::{add, changelog, config, errors::CreateError, github, inputs};
+use crate::{add, changelog, config, diff_prompt, errors::CreateError, github, inputs};
 
 /// Runs the main logic to open a new PR for the current branch.
 pub async fn run() -> Result<(), CreateError> {
@@ -33,10 +33,11 @@ pub async fn run() -> Result<(), CreateError> {
     let use_ai = inputs::get_use_ai()?;
     if use_ai {
         let diff = github::get_diff(git_info.branch.as_str(), target.as_str())?;
-        println!("{}", diff);
 
-        // TODO: implement sending diff to LLM and get suggestions for change type, cat, desc and pr
-        // body.
+        let response = diff_prompt::prompt(&config, diff.as_str()).await?;
+        // TODO: parse response to get suggested values
+        // TODO: use suggested values as defaults for inputs below
+        println!("{}", response);
     }
 
     panic!("check here");

--- a/src/create_pr.rs
+++ b/src/create_pr.rs
@@ -22,11 +22,6 @@ pub async fn run() -> Result<(), CreateError> {
         }
     };
 
-    let change_type = inputs::get_change_type(&config, 0)?;
-    let cat = inputs::get_category(&config, 0)?;
-    let desc = inputs::get_description("")?;
-    let pr_body = inputs::get_pr_description()?;
-
     let branches = client
         .repos(&git_info.owner, &git_info.repo)
         .list_branches()
@@ -34,6 +29,20 @@ pub async fn run() -> Result<(), CreateError> {
         .await?;
 
     let target = inputs::get_target_branch(branches)?;
+
+    // TODO: get input to check if user wants to use ai to suggest contents.
+    // TODO: implement getting diff to target branch
+    let diff = github::get_diff(git_info.branch.as_str(), target.as_str())?;
+    _ = diff;
+
+    // TODO: implement sending diff to LLM and get suggestions for change type, cat, desc and pr
+    // body.
+
+    // TODO: get default chosen values from the recommendations above
+    let change_type = inputs::get_change_type(&config, 0)?;
+    let cat = inputs::get_category(&config, 0)?;
+    let desc = inputs::get_description("")?;
+    let pr_body = inputs::get_pr_description()?;
 
     let ct = config.change_types.get(&change_type).unwrap();
     let title = format!("{ct}({cat}): {desc}");

--- a/src/create_pr.rs
+++ b/src/create_pr.rs
@@ -30,13 +30,16 @@ pub async fn run() -> Result<(), CreateError> {
 
     let target = inputs::get_target_branch(branches)?;
 
-    // TODO: get input to check if user wants to use ai to suggest contents.
-    // TODO: implement getting diff to target branch
-    let diff = github::get_diff(git_info.branch.as_str(), target.as_str())?;
-    _ = diff;
+    let use_ai = inputs::get_use_ai()?;
+    if use_ai {
+        let diff = github::get_diff(git_info.branch.as_str(), target.as_str())?;
+        println!("{}", diff);
 
-    // TODO: implement sending diff to LLM and get suggestions for change type, cat, desc and pr
-    // body.
+        // TODO: implement sending diff to LLM and get suggestions for change type, cat, desc and pr
+        // body.
+    }
+
+    panic!("check here");
 
     // TODO: get default chosen values from the recommendations above
     let change_type = inputs::get_change_type(&config, 0)?;

--- a/src/create_pr.rs
+++ b/src/create_pr.rs
@@ -56,7 +56,7 @@ pub async fn run() -> Result<(), CreateError> {
     add::add_entry(
         &config,
         &mut changelog,
-        &ct,
+        ct,
         &cat,
         &desc,
         created_pr.id.0 as u16,

--- a/src/diff_prompt.rs
+++ b/src/diff_prompt.rs
@@ -1,0 +1,17 @@
+use crate::{config::Config, errors::CreateError};
+use rig::{
+    completion::Prompt,
+    providers::anthropic::{self, CLAUDE_3_7_SONNET},
+};
+
+pub async fn prompt(config: &Config, diff: &str) -> Result<String, CreateError> {
+    let prompt = format!("{}\n{}", include_str!("diff_prompt.txt"), config);
+    let anthropic_client = anthropic::Client::from_env();
+    let sonnet = anthropic_client
+        .agent(CLAUDE_3_7_SONNET)
+        .preamble(prompt.as_str())
+        .max_tokens(1e3 as u64)
+        .build();
+
+    Ok(sonnet.prompt(diff).await?)
+}

--- a/src/diff_prompt.rs
+++ b/src/diff_prompt.rs
@@ -3,6 +3,7 @@ use rig::{
     completion::Prompt,
     providers::anthropic::{self, CLAUDE_3_7_SONNET},
 };
+use serde::Deserialize;
 
 pub async fn prompt(config: &Config, diff: &str) -> Result<String, CreateError> {
     let prompt = format!("{}\n{}", include_str!("diff_prompt.txt"), config);
@@ -14,4 +15,12 @@ pub async fn prompt(config: &Config, diff: &str) -> Result<String, CreateError> 
         .build();
 
     Ok(sonnet.prompt(diff).await?)
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct Suggestions {
+    pub category: String,
+    pub change_type: String,
+    pub title: String,
+    pub pr_description: String,
 }

--- a/src/diff_prompt.rs
+++ b/src/diff_prompt.rs
@@ -1,11 +1,22 @@
-use crate::{config::Config, errors::CreateError};
+use crate::{config::Config, errors::CreateError, github};
 use rig::{
     completion::Prompt,
     providers::anthropic::{self, CLAUDE_3_7_SONNET},
 };
 use serde::Deserialize;
 
-pub async fn prompt(config: &Config, diff: &str) -> Result<String, CreateError> {
+pub async fn get_suggestions(
+    config: &Config,
+    work_branch: &str,
+    pr_target: &str,
+) -> Result<Suggestions, CreateError> {
+    let diff = github::get_diff(work_branch, pr_target)?;
+    let response = prompt(config, diff.as_str()).await?;
+
+    Ok(serde_json::from_str(&response)?)
+}
+
+async fn prompt(config: &Config, diff: &str) -> Result<String, CreateError> {
     let prompt = format!("{}\n{}", include_str!("diff_prompt.txt"), config);
     let anthropic_client = anthropic::Client::from_env();
     let sonnet = anthropic_client

--- a/src/diff_prompt.rs
+++ b/src/diff_prompt.rs
@@ -10,7 +10,7 @@ pub async fn prompt(config: &Config, diff: &str) -> Result<String, CreateError> 
     let anthropic_client = anthropic::Client::from_env();
     let sonnet = anthropic_client
         .agent(CLAUDE_3_7_SONNET)
-        .preamble(prompt.as_str())
+        .preamble(&prompt)
         .max_tokens(1e3 as u64)
         .build();
 

--- a/src/diff_prompt.txt
+++ b/src/diff_prompt.txt
@@ -7,12 +7,13 @@ but provide enough context to understand everything
 and highlight the files with the most important changes.
 
 Attached to this message, you will find the configuration of the tool,
-that contains the enforced selection of categories like (cli), (tests) and change types like feat, imp, etc..
+that contains the enforced selection of categories like (cli), (tests) and change types like Features, Improvements, ...
 
 It is required to format the returned response in the form of the following JSON:
+
 {
     "category": "...",
-    "change_type": "...",
+    "change_type": "The (full) change type, so either Features, or ...",
     "title": "A one-line short summary of the made changes",
-    "pr-description": "A concise but thorough description of the made changes to be filled as the PR description."
+    "pr_description": "A concise but thorough description of the made changes to be filled as the PR description.\nThis should be returned with line return characters instead of actual new lines to make JSON parsing easier."
 }

--- a/src/diff_prompt.txt
+++ b/src/diff_prompt.txt
@@ -1,0 +1,18 @@
+You are part of a helper tool to create changelog entries in an automated fashion.
+You will be prompted and shall return a concise, one line summary / PR title
+that will be added to the changelog.
+Also, a concise description for the pull request should be formed.
+This should not be excessively long,
+but provide enough context to understand everything
+and highlight the files with the most important changes.
+
+Attached to this message, you will find the configuration of the tool,
+that contains the enforced selection of categories like (cli), (tests) and change types like feat, imp, etc..
+
+It is required to format the returned response in the form of the following JSON:
+{
+    "category": "...",
+    "change_type": "...",
+    "title": "A one-line short summary of the made changes",
+    "pr-description": "A concise but thorough description of the made changes to be filled as the PR description."
+}

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -25,7 +25,7 @@ impl Entry {
         pr_number: u16,
     ) -> Entry {
         let link = format!("{}/pull/{}", config.target_repo, pr_number);
-        let fixed = build_fixed(category, link.as_str(), description, pr_number);
+        let fixed = build_fixed(category, &link, description, pr_number);
 
         Entry {
             category: category.to_string(),
@@ -81,12 +81,7 @@ pub fn parse(config: &config::Config, line: &str) -> Result<Entry, EntryError> {
     let (fixed_desc, desc_problems) = check_description(config, description);
     desc_problems.into_iter().for_each(|p| problems.push(p));
 
-    let fixed = build_fixed(
-        fixed_category.as_str(),
-        fixed_link.as_str(),
-        fixed_desc.as_str(),
-        pr_number,
-    );
+    let fixed = build_fixed(&fixed_category, &fixed_link, &fixed_desc, pr_number);
 
     Ok(Entry {
         category: fixed_category.to_string(),
@@ -123,7 +118,7 @@ fn check_link(config: &config::Config, link: &str, pr_number: u16) -> (String, V
 
     let fixed = format!("{}/pull/{}", config.target_repo, pr_number);
 
-    if !link.starts_with(config.target_repo.as_str()) {
+    if !link.starts_with(&config.target_repo) {
         problems.push(format!("PR link points to wrong repository: {}", link))
     }
 
@@ -166,7 +161,7 @@ pub fn check_description(config: &config::Config, desc: &str) -> (String, Vec<St
         problems.push(format!("PR description should end with a dot: '{}'", desc))
     }
 
-    let (fixed, spelling_problems) = check_spelling(config, fixed.as_str());
+    let (fixed, spelling_problems) = check_spelling(config, &fixed);
     spelling_problems.into_iter().for_each(|p| problems.push(p));
 
     (fixed, problems)
@@ -191,7 +186,7 @@ fn check_spelling(config: &config::Config, text: &str) -> (String, Vec<String>) 
                             pattern
                         )
                     })
-                    .replace(fixed.as_str(), correct_spelling)
+                    .replace(&fixed, correct_spelling)
                     .to_string();
 
                 problems.push(format!(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -37,6 +37,8 @@ pub enum CreateError {
     ExistingPR(u64),
     #[error("failed to create PR: {0}")]
     FailedToCreatePR(#[from] octocrab::Error),
+    #[error("failed to parse llm suggestions: {0}")]
+    FailedToParse(#[from] serde_json::Error),
     #[error("error interacting with GitHub: {0}")]
     GitHub(#[from] GitHubError),
     #[error("error getting user input: {0}")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -120,6 +120,8 @@ pub enum EntryError {
 pub enum GitHubError {
     #[error("failed to get current branch")]
     CurrentBranch,
+    #[error("failed to get diff")]
+    Diff,
     #[error("failed to commit changes")]
     FailedToCommit,
     #[error("failed to push to origin")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,6 @@
 use inquire::InquireError;
 use regex::Error;
+use rig::completion::PromptError;
 use serde_json;
 use std::{env::VarError, io, num::ParseIntError, string::FromUtf8Error};
 use thiserror::Error;
@@ -40,6 +41,8 @@ pub enum CreateError {
     GitHub(#[from] GitHubError),
     #[error("error getting user input: {0}")]
     Input(#[from] InputError),
+    #[error("failed to prompt llm: {0}")]
+    Prompt(#[from] PromptError),
 }
 
 #[derive(Error, Debug)]

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -2,14 +2,19 @@ use crate::{config::Config, errors::InputError, release_type::ReleaseType};
 use inquire::{Confirm, Editor, Select, Text};
 use octocrab::{models::repos::Branch, Page};
 
-pub fn get_change_type(config: &Config, start: usize) -> Result<String, InputError> {
+pub fn get_change_type(config: &Config, suggestion: &str) -> Result<String, InputError> {
     let mut selectable_change_types: Vec<String> =
         config.change_types.clone().into_keys().collect();
     selectable_change_types.sort();
 
+    let ct_idx = selectable_change_types
+        .iter()
+        .position(|ct| ct.eq(suggestion))
+        .unwrap_or_default();
+
     Ok(
         Select::new("Select change type to add into:", selectable_change_types)
-            .with_starting_cursor(start)
+            .with_starting_cursor(ct_idx)
             .prompt()?,
     )
 }
@@ -21,12 +26,18 @@ pub fn get_pr_number(default_value: u16) -> Result<u16, InputError> {
         .parse::<u16>()?)
 }
 
-pub fn get_category(config: &Config, default_idx: usize) -> Result<String, InputError> {
+pub fn get_category(config: &Config, suggestion: &str) -> Result<String, InputError> {
+    let idx = config
+        .categories
+        .iter()
+        .position(|cat| cat.eq(suggestion))
+        .unwrap_or_default();
+
     Ok(Select::new(
         "Select the category of the made changes:",
         config.categories.clone(),
     )
-    .with_starting_cursor(default_idx)
+    .with_starting_cursor(idx)
     .prompt()?)
 }
 
@@ -61,10 +72,11 @@ pub fn get_permission_to_push(branch: &str) -> Result<bool, InputError> {
     }
 }
 
-pub fn get_pr_description() -> Result<String, InputError> {
+pub fn get_pr_description(suggestion: &str) -> Result<String, InputError> {
     Ok(Editor::new(
         "Please provide the Pull Request body with a description of the made changes.\n",
     )
+    .with_predefined_text(suggestion)
     .prompt()?)
 }
 

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -1,5 +1,5 @@
 use crate::{config::Config, errors::InputError, release_type::ReleaseType};
-use inquire::{Editor, Select, Text};
+use inquire::{Confirm, Editor, Select, Text};
 use octocrab::{models::repos::Branch, Page};
 
 pub fn get_change_type(config: &Config, start: usize) -> Result<String, InputError> {
@@ -101,4 +101,12 @@ pub fn get_target_branch(branches_page: Page<Branch>) -> Result<String, InputErr
     )
     .with_starting_cursor(start_idx)
     .prompt()?)
+}
+
+pub fn get_use_ai() -> Result<bool, InputError> {
+    Ok(
+        Confirm::new(
+            "Do you want to use AI to suggest changelog contents? Requires API keys to be set in environment. (y/n)\n")
+        .prompt()?
+    )
 }

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -43,7 +43,7 @@ pub fn get_category(config: &Config, suggestion: &str) -> Result<String, InputEr
 
 pub fn get_commit_message(config: &Config) -> Result<String, InputError> {
     Ok(Text::new("Please provide the commit message:\n")
-        .with_initial_value(config.commit_message.as_str())
+        .with_initial_value(&config.commit_message)
         .prompt()?)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod cli;
 pub mod cli_config;
 pub mod config;
 pub mod create_pr;
+pub mod diff_prompt;
 mod entry;
 pub mod errors;
 mod escapes;


### PR DESCRIPTION
This PR adds the capability to use AI (Claude) to suggest changelog entries based on the diff between branches when creating a PR.

Key changes:
- Integrated `rig-core` for LLM interactions (Claude 3.7 Sonnet)
- Added a new `diff_prompt.rs` module that sends diffs to the LLM and parses responses
- Modified the PR creation flow to optionally use AI suggestions
- Updated input functions to accept suggestions from AI
- Added a user confirmation prompt before using the AI feature

The AI suggests appropriate category, change type, title, and PR description based on the code changes, which the user can then edit before submitting.