### PR TITLE
imp(config): Convert to have deterministic order of change types

### DIFF
--- a/.clconfig.json
+++ b/.clconfig.json
@@ -10,13 +10,22 @@
     "release",
     "test"
   ],
-  "change_types": {
-    "Bug Fixes": "fix",
-    "Features": "feat",
-    "Improvements": "imp"
-  },
-  "changelog_path": "CHANGELOG.md",
+  "change_types": [
+    {
+      "short": "feat",
+      "long": "Features"
+    },
+    {
+      "short": "imp",
+      "long": "Improvements"
+    },
+    {
+      "short": "fix",
+      "long": "Bug Fixes"
+    }
+  ],
   "commit_message": "add changelog entry",
+  "changelog_path": "CHANGELOG.md",
   "expected_spellings": {
     "CLI": "cli"
   },

--- a/.clconfig.json
+++ b/.clconfig.json
@@ -10,22 +10,13 @@
     "release",
     "test"
   ],
-  "change_types": [
-    {
-      "short": "feat",
-      "long": "Features"
-    },
-    {
-      "short": "imp",
-      "long": "Improvements"
-    },
-    {
-      "short": "fix",
-      "long": "Bug Fixes"
-    }
-  ],
-  "commit_message": "add changelog entry",
+  "change_types": {
+    "Bug Fixes": "fix",
+    "Features": "feat",
+    "Improvements": "imp"
+  },
   "changelog_path": "CHANGELOG.md",
+  "commit_message": "add changelog entry",
   "expected_spellings": {
     "CLI": "cli"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This changelog was created using the `clu` binary
 
 ### Improvements
 
+- (config) [#80](https://github.com/MalteHerrmann/changelog-utils/pull/80) Convert to have deterministic order of change types in config.
 - (cli) [#76](https://github.com/MalteHerrmann/changelog-utils/pull/76) Improve error handling when creating a PR and only the local changelog commit fails.
 
 ### Features

--- a/src/add.rs
+++ b/src/add.rs
@@ -18,9 +18,11 @@ fn get_entry_inputs(
     accept: bool,
     retrieved: bool,
 ) -> Result<(String, u16, String, String), AddError> {
-    let mut selectable_change_types: Vec<String> =
-        config.change_types.clone().into_keys().collect();
-    selectable_change_types.sort();
+    let selectable_change_types: Vec<String> = config
+        .change_types
+        .iter()
+        .map(|ct| ct.long.to_owned())
+        .collect();
 
     // populate the map with false if user input is not required, otherwise true
     let mut get_inputs: HashMap<&str, bool> =

--- a/src/change_type.rs
+++ b/src/change_type.rs
@@ -35,14 +35,14 @@ pub fn parse(config: config::Config, line: &str) -> Result<ChangeType, ChangeTyp
     let mut problems: Vec<String> = Vec::new();
 
     // Check the correctness of the current change type.
-    if !config.change_types.iter().any(|(change_type, _)| {
+    if !config.change_types.iter().any(|ct| {
         // derive the generalized pattern with case insensitivity and whitespace
         // matching from the given change type
         let pattern = RegexBuilder::new(r"\s+")
             .case_insensitive(true)
             .build()
             .unwrap()
-            .replace_all(change_type, r"\s*")
+            .replace_all(&ct.long, r"\s*")
             .into_owned();
 
         if !RegexBuilder::new(pattern.as_str())
@@ -54,11 +54,12 @@ pub fn parse(config: config::Config, line: &str) -> Result<ChangeType, ChangeTyp
             return false;
         }
 
-        if name != change_type {
+        if name != ct.long {
             problems.push(format!(
-                "'{change_type}' should be used instead of '{name}'"
+                "'{}' should be used instead of '{}'",
+                ct.long, name
             ));
-            change_type.clone_into(&mut fixed_name);
+            fixed_name.clone_from(&ct.long);
         }
 
         true

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -1,7 +1,12 @@
-use crate::{change_type, config::Config, entry, errors::ChangelogError, escapes, release};
+use crate::{
+    change_type,
+    config::{ChangeTypeConfig, Config},
+    entry,
+    errors::ChangelogError,
+    escapes, release,
+};
 use regex::Regex;
 use std::{
-    collections::BTreeMap,
     fs,
     path::{Path, PathBuf},
 };
@@ -366,16 +371,17 @@ pub fn get_settings_from_existing_changelog(config: &mut Config, contents: &str)
         }
     }
 
-    let mut change_types: BTreeMap<String, String> = BTreeMap::new();
+    let mut change_type_configs: Vec<ChangeTypeConfig> = Vec::new();
     seen_change_types.into_iter().for_each(|ct| {
-        let pattern = regex::Regex::new(r"\s+")
-            .unwrap()
-            .replace_all(&ct, "\\s*")
-            .to_ascii_lowercase();
-        change_types.insert(ct, pattern);
+        let pattern = ct[0..4].trim().to_ascii_lowercase();
+
+        change_type_configs.push(ChangeTypeConfig {
+            short: pattern,
+            long: ct,
+        });
     });
 
     seen_categories.sort();
     config.categories = seen_categories;
-    config.change_types = change_types;
+    config.change_types = change_type_configs;
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,7 +41,7 @@ pub enum ConfigSubcommands {
     #[command(
         about = "Adjust the allowed change types within releases (like 'Bug Fixes', 'Features', etc.)"
     )]
-    ChangeType(KeyValueArgs),
+    ChangeType(ChangeTypeArgs),
     #[command(about = "Set or unset the optional legacy version")]
     LegacyVersion(ConditionalArgs),
     #[command(about = "Shows the current configuration")]
@@ -74,6 +74,20 @@ pub enum CategoryOperation {
     Add { value: String },
     #[command(about = "Removes a category if it is set in the configuration")]
     Remove { value: String },
+}
+
+#[derive(Args, Debug)]
+pub struct ChangeTypeArgs {
+    #[command(subcommand)]
+    pub command: ChangeTypeConfigOperation,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ChangeTypeConfigOperation {
+    #[command(about = "Add a new change type configuration entry")]
+    Add { long: String, short: String },
+    #[command(about = "Remove a change type configuration entry")]
+    Remove { short: String },
 }
 
 #[derive(Args, Debug)]

--- a/src/cli_config.rs
+++ b/src/cli_config.rs
@@ -1,7 +1,9 @@
 use crate::{
     cli::{
-        CategoryOperation, ConfigSubcommands,
-        ConfigSubcommands::{Category, ChangeType, LegacyVersion, Show, Spelling, TargetRepo},
+        CategoryOperation, ChangeTypeConfigOperation,
+        ConfigSubcommands::{
+            self, Category, ChangeType, LegacyVersion, Show, Spelling, TargetRepo,
+        },
         KeyValueOperation, OptionalOperation,
     },
     config, errors,
@@ -20,11 +22,11 @@ pub fn adjust_config(config_subcommand: ConfigSubcommands) -> Result<(), errors:
             }
         },
         ChangeType(args) => match args.command {
-            KeyValueOperation::Add { key, value } => {
-                config::add_into_collection(&mut configuration.change_types, key, value)?
+            ChangeTypeConfigOperation::Add { long, short } => {
+                config::add_change_type(&mut configuration, &long, &short)?
             }
-            KeyValueOperation::Remove { key } => {
-                config::remove_from_collection(&mut configuration.change_types, key)?
+            ChangeTypeConfigOperation::Remove { short } => {
+                config::remove_change_type(&mut configuration, &short)?
             }
         },
         Show => println!("{}", configuration),

--- a/src/config.rs
+++ b/src/config.rs
@@ -314,6 +314,57 @@ mod config_adjustment_tests {
     }
 
     #[test]
+    fn test_add_change_type() {
+        let mut config = load_example_config();
+        assert_eq!(config.change_types.len(), 3);
+        assert!(add_change_type(&mut config, "LONG CHANGE TYPE", "SHORT").is_ok());
+        assert_eq!(config.change_types.len(), 4);
+        assert_eq!(
+            config.change_types[3],
+            ChangeTypeConfig {
+                short: "SHORT".into(),
+                long: "LONG CHANGE TYPE".into()
+            }
+        );
+    }
+
+    #[test]
+    fn test_add_change_type_duplicate() {
+        let mut config = load_example_config();
+        assert_eq!(config.change_types.len(), 3);
+        assert!(add_change_type(&mut config, "Bug Fixes", "fix").is_err());
+        assert_eq!(config.change_types.len(), 3);
+    }
+
+    #[test]
+    fn test_get_short_change_type() {
+        let config = load_example_config();
+        assert!(config.get_short_change_type("fix").is_some());
+        assert!(config.get_short_change_type("abcde").is_none());
+    }
+
+    #[test]
+    fn test_get_long_change_type() {
+        let config = load_example_config();
+        assert!(config.get_long_change_type("Bug Fixes").is_some());
+        assert!(config.get_long_change_type("non-existente").is_none());
+    }
+
+    #[test]
+    fn test_remove_change_type() {
+        let mut config = load_example_config();
+        assert_eq!(config.change_types.len(), 3);
+        assert!(config.get_long_change_type("Bug Fixes").is_some());
+
+        assert!(remove_change_type(&mut config, "fix").is_ok());
+        assert_eq!(config.change_types.len(), 2);
+        assert!(config.get_long_change_type("Bug Fixes").is_none());
+
+        assert!(remove_change_type(&mut config, "abcde").is_err());
+        assert_eq!(config.change_types.len(), 2);
+    }
+
+    #[test]
     fn test_add_into_collection() {
         let mut config = load_example_config();
         assert_eq!(config.expected_spellings.keys().len(), 3);

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,14 +47,14 @@ impl Config {
         self.change_types
             .iter()
             .find(|&ct| ct.long.eq(long))
-            .map(|ct| ct.clone())
+            .cloned()
     }
 
     pub fn get_short_change_type(&self, short: &str) -> Option<ChangeTypeConfig> {
         self.change_types
             .iter()
             .find(|&ct| ct.short.eq(short))
-            .map(|ct| ct.clone())
+            .cloned()
     }
 }
 
@@ -140,10 +140,11 @@ pub fn add_change_type(
         return Err(ConfigAdjustError::DuplicateChangeType(long.into()));
     };
 
-    Ok(config.change_types.push(ChangeTypeConfig {
+    config.change_types.push(ChangeTypeConfig {
         short: short.into(),
         long: long.into(),
-    }))
+    });
+    Ok(())
 }
 
 pub fn remove_change_type(config: &mut Config, short: &str) -> Result<(), ConfigAdjustError> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,12 +10,8 @@ pub struct Config {
     /// The list of categories for a given entry,
     /// that can be used.
     pub categories: Vec<String>,
-    /// The map of allowed change types.
-    ///
-    /// Note: The key is the full spelling and the value is
-    /// an abbreviation that is to be used as a short form
-    /// in pull request titles.
-    pub change_types: BTreeMap<String, String>,
+    /// The list of allowed change types.
+    pub change_types: Vec<ChangeTypeConfig>,
     /// The default commit message to be used when committing
     /// the new changelog entry.
     pub commit_message: String,
@@ -46,6 +42,20 @@ impl Config {
     pub fn has_legacy_version(&self) -> bool {
         self.legacy_version.is_some()
     }
+
+    pub fn get_long_change_type(&self, long: &str) -> Option<ChangeTypeConfig> {
+        self.change_types
+            .iter()
+            .find(|&ct| ct.long.eq(long))
+            .map(|ct| ct.clone())
+    }
+
+    pub fn get_short_change_type(&self, short: &str) -> Option<ChangeTypeConfig> {
+        self.change_types
+            .iter()
+            .find(|&ct| ct.short.eq(short))
+            .map(|ct| ct.clone())
+    }
 }
 
 impl fmt::Display for Config {
@@ -56,10 +66,20 @@ impl fmt::Display for Config {
 
 impl Default for Config {
     fn default() -> Config {
-        let mut default_change_types: BTreeMap<String, String> = BTreeMap::new();
-        default_change_types.insert("Bug Fixes".into(), "fix".into());
-        default_change_types.insert("Features".into(), "feat".into());
-        default_change_types.insert("Improvements".into(), "imp".into());
+        let default_change_types = vec![
+            ChangeTypeConfig {
+                short: "feat".into(),
+                long: "Features".into(),
+            },
+            ChangeTypeConfig {
+                short: "imp".into(),
+                long: "Improvements".into(),
+            },
+            ChangeTypeConfig {
+                short: "fix".into(),
+                long: "Bug Fixes".into(),
+            },
+        ];
 
         let commit_message = "add changelog entry".to_string();
         let changelog_path = "CHANGELOG.md".to_string();
@@ -109,6 +129,41 @@ pub fn remove_category(config: &mut Config, value: String) -> Result<(), ConfigA
     config.categories.remove(index);
 
     Ok(())
+}
+
+pub fn add_change_type(
+    config: &mut Config,
+    long: &str,
+    short: &str,
+) -> Result<(), ConfigAdjustError> {
+    if config.get_long_change_type(long).is_some() {
+        return Err(ConfigAdjustError::DuplicateChangeType(long.into()));
+    };
+
+    Ok(config.change_types.push(ChangeTypeConfig {
+        short: short.into(),
+        long: long.into(),
+    }))
+}
+
+pub fn remove_change_type(config: &mut Config, short: &str) -> Result<(), ConfigAdjustError> {
+    let i = match config.change_types.iter().position(|ct| ct.short.eq(short)) {
+        Some(i) => i,
+        None => return Err(ConfigAdjustError::NotFound),
+    };
+
+    config.change_types.remove(i);
+    Ok(())
+}
+
+// This type defines the information about a change type.
+// This consists of a short version of the long-form change type.
+//
+// Examples: short: imp; long: Improvements
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ChangeTypeConfig {
+    pub short: String,
+    pub long: String,
 }
 
 // Adds a new key-value pair into the given collection in case the key is not
@@ -172,7 +227,13 @@ mod config_tests {
             config.change_types.len() > 0,
             "expected non-zero length of change types in example config"
         );
-        assert_eq!(config.change_types.get("Bug Fixes").unwrap(), "fix");
+        assert_eq!(
+            config.get_long_change_type("Bug Fixes").unwrap(),
+            ChangeTypeConfig {
+                short: "fix".into(),
+                long: "Bug Fixes".into()
+            }
+        );
 
         assert!(
             config.categories.len() > 0,
@@ -254,54 +315,55 @@ mod config_adjustment_tests {
     #[test]
     fn test_add_into_collection() {
         let mut config = load_example_config();
-        assert_eq!(config.change_types.keys().len(), 3);
-        assert!(!config.change_types.contains_key("newkey"));
+        assert_eq!(config.expected_spellings.keys().len(), 3);
+        assert!(!config.expected_spellings.contains_key("newkey"));
         assert!(add_into_collection(
-            &mut config.change_types,
+            &mut config.expected_spellings,
             "newkey".to_string(),
             "newvalue".to_string()
         )
         .is_ok());
-        assert_eq!(config.change_types.keys().len(), 4);
-        assert!(config.change_types.contains_key("newkey"));
+        assert_eq!(config.expected_spellings.keys().len(), 4);
+        assert!(config.expected_spellings.contains_key("newkey"));
     }
 
     #[test]
     fn test_add_into_collection_already_present() {
         let mut config = load_example_config();
-        assert_eq!(config.change_types.keys().len(), 3);
-        assert!(config.change_types.contains_key("Bug Fixes"));
+        assert_eq!(config.expected_spellings.keys().len(), 3);
+        assert!(config.expected_spellings.contains_key("API"));
         assert_eq!(
             add_into_collection(
-                &mut config.change_types,
-                "Bug Fixes".to_string(),
+                &mut config.expected_spellings,
+                "API".to_string(),
                 "newvalue".to_string()
             )
             .unwrap_err(),
             ConfigAdjustError::KeyAlreadyFound
         );
-        assert_eq!(config.change_types.keys().len(), 3);
+        assert_eq!(config.expected_spellings.keys().len(), 3);
     }
 
     #[test]
     fn test_remove_from_collection() {
         let mut config = load_example_config();
-        assert_eq!(config.change_types.keys().len(), 3);
-        assert!(config.change_types.contains_key("Bug Fixes"));
-        assert!(remove_from_collection(&mut config.change_types, "Bug Fixes".to_string()).is_ok());
-        assert_eq!(config.change_types.keys().len(), 2);
-        assert!(!config.change_types.contains_key("Bug Fixes"));
+        assert_eq!(config.expected_spellings.keys().len(), 3);
+        assert!(config.expected_spellings.contains_key("API"));
+        assert!(remove_from_collection(&mut config.expected_spellings, "API".to_string()).is_ok());
+        assert_eq!(config.expected_spellings.keys().len(), 2);
+        assert!(!config.expected_spellings.contains_key("API"));
     }
 
     #[test]
     fn test_remove_from_collection_not_found() {
         let mut config = load_example_config();
-        assert_eq!(config.change_types.keys().len(), 3);
+        assert_eq!(config.expected_spellings.keys().len(), 3);
         assert_eq!(
-            remove_from_collection(&mut config.change_types, "not found".to_string()).unwrap_err(),
+            remove_from_collection(&mut config.expected_spellings, "not found".to_string())
+                .unwrap_err(),
             ConfigAdjustError::NotFound
         );
-        assert_eq!(config.change_types.keys().len(), 3);
+        assert_eq!(config.expected_spellings.keys().len(), 3);
     }
 
     #[test]

--- a/src/create_pr.rs
+++ b/src/create_pr.rs
@@ -44,7 +44,7 @@ pub async fn run() -> Result<(), CreateError> {
     let desc = inputs::get_description(&suggestions.title)?;
     let pr_body = inputs::get_pr_description(&suggestions.pr_description)?;
 
-    let ct = config.change_types.get(&change_type).unwrap();
+    let ct = config.get_long_change_type(&change_type).unwrap().short;
     let title = format!("{ct}({cat}): {desc}");
 
     let created_pr = client

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -175,6 +175,8 @@ pub enum ConfigAdjustError {
     CategoryAlreadyFound,
     #[error("key is already present in hash map")]
     KeyAlreadyFound,
+    #[error("duplicate change type: {0}")]
+    DuplicateChangeType(String),
     #[error("Invalid URL")]
     InvalidURL(#[from] url::ParseError),
     #[error("expected value not found")]

--- a/src/github.rs
+++ b/src/github.rs
@@ -23,19 +23,15 @@ fn extract_pr_info(config: &Config, pr: &PullRequest) -> Result<PRInfo, GitHubEr
     let mut category = String::new();
     let mut description = String::new();
 
-    let pr_title = pr.title.clone().unwrap_or("".to_string());
+    let pr_title = pr.title.clone().unwrap_or_default();
 
     if let Some(i) = RegexBuilder::new(r"^(?P<ct>\w+)?\s*(\((?P<cat>\w+)\))?[:\s]*(?P<desc>.+)$")
         .build()?
         .captures(pr_title.as_str())
     {
         if let Some(ct) = i.name("ct") {
-            if let Some((name, _)) = config
-                .change_types
-                .iter()
-                .find(|&(_, abbrev)| abbrev.eq(ct.into()))
-            {
-                change_type.clone_from(name);
+            if let Some(found_ct) = config.get_short_change_type(ct.as_str()) {
+                change_type.clone_from(&found_ct.short);
             }
         };
 

--- a/src/inputs.rs
+++ b/src/inputs.rs
@@ -3,9 +3,11 @@ use inquire::{Confirm, Editor, Select, Text};
 use octocrab::{models::repos::Branch, Page};
 
 pub fn get_change_type(config: &Config, suggestion: &str) -> Result<String, InputError> {
-    let mut selectable_change_types: Vec<String> =
-        config.change_types.clone().into_keys().collect();
-    selectable_change_types.sort();
+    let selectable_change_types: Vec<String> = config
+        .change_types
+        .iter()
+        .map(|ct| ct.long.clone())
+        .collect();
 
     let ct_idx = selectable_change_types
         .iter()

--- a/src/testdata/example_config.json
+++ b/src/testdata/example_config.json
@@ -1,10 +1,19 @@
 {
   "categories": ["cli", "test"],
-  "change_types": {
-    "Bug Fixes": "fix",
-    "Improvements": "imp",
-    "Features": "feat"
-  },
+  "change_types": [
+    {
+      "long": "Features",
+      "short": "feat"
+    },
+    {
+      "long": "Improvements",
+      "short": "imp"
+    },
+    {
+      "long": "Bug Fixes",
+      "short": "fix"
+    }
+  ],
   "changelog_path": "CHANGELOG.md",
   "commit_message": "add changelog entry",
   "expected_spellings": {

--- a/src/testdata/example_config_without_optionals.json
+++ b/src/testdata/example_config_without_optionals.json
@@ -1,10 +1,19 @@
 {
   "categories": ["cli", "test"],
-  "change_types": {
-    "Bug Fixes": "fix",
-    "Improvements": "imp",
-    "Features": "feat"
-  },
+  "change_types": [
+    {
+      "long": "Features",
+      "short": "feat"
+    },
+    {
+      "long": "Improvements",
+      "short": "imp"
+    },
+    {
+      "long": "Bug Fixes",
+      "short": "fix"
+    }
+  ],
   "changelog_path": "CHANGELOG.md",
   "commit_message": "add changelog entry",
   "expected_spellings": {

--- a/tests/init_test.rs
+++ b/tests/init_test.rs
@@ -1,7 +1,11 @@
 use assert_fs::{prelude::*, TempDir};
-use clu::{config, errors::InitError, init};
+use clu::{
+    config::{self, ChangeTypeConfig},
+    errors::InitError,
+    init,
+};
 use predicates::prelude::*;
-use std::{collections::BTreeMap, fs};
+use std::fs;
 
 #[test]
 fn test_init_empty_folder() {
@@ -69,16 +73,28 @@ fn test_init_changelog_exists() {
         ]
     );
 
-    let expected_change_types: BTreeMap<String, String> = BTreeMap::from([
-        ("Improvements".into(), "improvements".into()),
-        ("Bug Fixes".into(), "bug\\s*fixes".into()),
-        ("API Breaking".into(), "api\\s*breaking".into()),
-        (
-            "State Machine Breaking".into(),
-            "state\\s*machine\\s*breaking".into(),
-        ),
-        ("Invalid Category".into(), "invalid\\s*category".into()),
-    ]);
+    let expected_change_types = vec![
+        ChangeTypeConfig {
+            long: "State Machine Breaking".into(),
+            short: "stat".into(),
+        },
+        ChangeTypeConfig {
+            long: "API Breaking".into(),
+            short: "api".into(),
+        },
+        ChangeTypeConfig {
+            long: "Improvements".into(),
+            short: "impr".into(),
+        },
+        ChangeTypeConfig {
+            long: "Bug Fixes".into(),
+            short: "bug".into(),
+        },
+        ChangeTypeConfig {
+            long: "Invalid Category".into(),
+            short: "inva".into(),
+        },
+    ];
 
     assert_eq!(config.change_types, expected_change_types);
 }

--- a/tests/testdata/evmos_config.json
+++ b/tests/testdata/evmos_config.json
@@ -14,13 +14,13 @@
     "app",
     "all"
   ],
-  "change_types": {
-    "Bug Fixes": "fix",
-    "Improvements": "imp",
-    "Features": "feat",
-    "State Machine Breaking": "imp",
-    "API Breaking": "imp"
-  },
+  "change_types": [
+    { "long": "Features", "short": "feat" },
+    { "long": "State Machine Breaking", "short": "imp" },
+    { "long": "API Breaking", "short": "imp" },
+    { "long": "Improvements", "short": "imp" },
+    { "long": "Bug Fixes", "short": "fix" }
+  ],
   "changelog_path": "CHANGELOG.md",
   "commit_message": "add changelog entry",
   "expected_spellings": {


### PR DESCRIPTION
- **refactors to allow deterministic order of change types when printing contents**
- **adjust clu config in repo**
- **address linters**

----

Closes #73
