### PR TITLE
fix(cli): Fix PR number insert when creating new PR

### DIFF
--- a/.clconfig.json
+++ b/.clconfig.json
@@ -10,11 +10,11 @@
     "release",
     "test"
   ],
-  "change_types": {
-    "Bug Fixes": "fix",
-    "Features": "feat",
-    "Improvements": "imp"
-  },
+  "change_types": [
+    {"short": "feat", "long": "Features"},
+    {"short": "imp", "long": "Improvements"},
+    {"short": "fix", "long": "Bug Fixes"}
+  ],
   "changelog_path": "CHANGELOG.md",
   "commit_message": "add changelog entry",
   "expected_spellings": {

--- a/.clconfig.json
+++ b/.clconfig.json
@@ -10,11 +10,11 @@
     "release",
     "test"
   ],
-  "change_types": [
-    {"short": "feat", "long": "Features"},
-    {"short": "imp", "long": "Improvements"},
-    {"short": "fix", "long": "Bug Fixes"}
-  ],
+  "change_types": {
+    "Bug Fixes": "fix",
+    "Features": "feat",
+    "Improvements": "imp"
+  },
   "changelog_path": "CHANGELOG.md",
   "commit_message": "add changelog entry",
   "expected_spellings": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This changelog was created using the `clu` binary
 
 - (cli) [#83](https://github.com/MalteHerrmann/changelog-utils/pull/83) Improve JSON parsing from LLM responses with regex extraction.
 
+### Bug Fixes
+
+- (cli) [#86](https://github.com/MalteHerrmann/changelog-utils/pull/86) Fix PR number insert when creating new PR.
+
 ## [v1.4.0](https://github.com/MalteHerrmann/changelog-utils/releases/tag/v1.4.0) - 2025-05-15
 
 ### Bug Fixes

--- a/src/create_pr.rs
+++ b/src/create_pr.rs
@@ -60,6 +60,11 @@ pub async fn run() -> Result<(), CreateError> {
             .html_url
             .expect("received no error creating the PR but html_url was None")
     );
+    
+    println!("got PR number: {}", created_pr.number as u16);
+    println!("got PR ID: {}", created_pr.id.0 as u16);
+    
+    let pr_number: u16 = created_pr.number.try_into().map_err(CreateError::OutOfRange)?;
 
     let mut changelog = changelog::load(config.clone())?;
     add::add_entry(
@@ -68,7 +73,7 @@ pub async fn run() -> Result<(), CreateError> {
         &change_type,
         &cat,
         &desc,
-        created_pr.id.0 as u16,
+        pr_number,
     );
 
     changelog.write(&changelog.path)?;

--- a/src/create_pr.rs
+++ b/src/create_pr.rs
@@ -61,9 +61,6 @@ pub async fn run() -> Result<(), CreateError> {
             .expect("received no error creating the PR but html_url was None")
     );
     
-    println!("got PR number: {}", created_pr.number as u16);
-    println!("got PR ID: {}", created_pr.id.0 as u16);
-    
     let pr_number: u16 = created_pr.number.try_into().map_err(CreateError::OutOfRange)?;
 
     let mut changelog = changelog::load(config.clone())?;
@@ -80,7 +77,8 @@ pub async fn run() -> Result<(), CreateError> {
 
     let cm = inputs::get_commit_message(&config)?;
     if let Err(e) = github::commit_and_push(&config, &cm) {
-        // NOTE: we don't want to fail here since the PR was created successfully, just the commit of the changelog failed
+        // NOTE: we don't want to fail here since the PR was created successfully,
+        // just the commit of the changelog failed
         println!("failed to commit and push changes: {}", e);
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,6 +3,7 @@ use regex::Error;
 use rig::completion::PromptError;
 use serde_json;
 use std::{env::VarError, io, num::ParseIntError, string::FromUtf8Error};
+use std::num::TryFromIntError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -45,6 +46,8 @@ pub enum CreateError {
     GitHub(#[from] GitHubError),
     #[error("error getting user input: {0}")]
     Input(#[from] InputError),
+    #[error("failed to convert PR number into u16: {0}")]
+    OutOfRange(#[from] TryFromIntError),
     #[error("failed to prompt llm: {0}")]
     Prompt(#[from] PromptError),
 }


### PR DESCRIPTION
This PR improves how PR numbers are handled in the changelog utils to prevent potential numeric overflows. It converts the PR number to u16 with proper error handling instead of using a potentially unsafe cast from the GitHub API response.

Key changes:
- Added conversion from PR number to u16 with proper error handling
- Updated error handling with a new OutOfRange variant
- Added TryFromIntError import to handle conversion errors