### PR TITLE
feat(cli): Add version flag to CLI application

### DIFF
--- a/.clconfig.json
+++ b/.clconfig.json
@@ -10,11 +10,11 @@
     "release",
     "test"
   ],
-  "change_types": [
-    {"short": "fix", "long": "Bug Fixes"},
-    {"short": "feat", "long": "Features"},
-    {"short": "imp", "long": "Improvements"}
-  ],
+  "change_types": {
+    "Bug Fixes": "fix",
+    "Features": "feat",
+    "Improvements": "imp"
+  },
   "changelog_path": "CHANGELOG.md",
   "commit_message": "add changelog entry",
   "expected_spellings": {

--- a/.clconfig.json
+++ b/.clconfig.json
@@ -10,11 +10,11 @@
     "release",
     "test"
   ],
-  "change_types": {
-    "Bug Fixes": "fix",
-    "Features": "feat",
-    "Improvements": "imp"
-  },
+  "change_types": [
+    {"short": "fix", "long": "Bug Fixes"},
+    {"short": "feat", "long": "Features"},
+    {"short": "imp", "long": "Improvements"}
+  ],
   "changelog_path": "CHANGELOG.md",
   "commit_message": "add changelog entry",
   "expected_spellings": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This changelog was created using the `clu` binary
 
 - (cli) [#86](https://github.com/MalteHerrmann/changelog-utils/pull/86) Fix PR number insert when creating new PR.
 
+### Features
+
+- (cli) [#87](https://github.com/MalteHerrmann/changelog-utils/pull/87) Add version flag to CLI application.
+
 ## [v1.4.0](https://github.com/MalteHerrmann/changelog-utils/releases/tag/v1.4.0) - 2025-05-15
 
 ### Bug Fixes

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Parser, Subcommand};
 
 #[derive(Parser, Debug)]
+#[command(version)]
 pub enum ChangelogCLI {
     #[command(about = "Adds a new entry to the unreleased section of the changelog")]
     Add(AddArgs),


### PR DESCRIPTION
This PR adds version information to the CLI application by implementing the `#[command(version)]` attribute to the top-level command struct. This allows users to view the application version by using the `--version` flag when running the application.

Changes:
- Added version attribute to the `ChangelogCLI` enum in src/cli.rs