### PR TITLE
imp(all): Refactor fixed contents export for better maintainability

### DIFF
--- a/.clconfig.json
+++ b/.clconfig.json
@@ -10,11 +10,11 @@
     "release",
     "test"
   ],
-  "change_types": [
-    {"short": "fix", "long": "Bug Fixes"},
-    {"short": "feat", "long": "Features"},
-    {"short": "imp", "long": "Improvements"}
-  ],
+  "change_types": {
+    "Bug Fixes": "fix",
+    "Features": "feat",
+    "Improvements": "imp"
+  },
   "changelog_path": "CHANGELOG.md",
   "commit_message": "add changelog entry",
   "expected_spellings": {

--- a/.clconfig.json
+++ b/.clconfig.json
@@ -10,11 +10,11 @@
     "release",
     "test"
   ],
-  "change_types": {
-    "Bug Fixes": "fix",
-    "Features": "feat",
-    "Improvements": "imp"
-  },
+  "change_types": [
+    {"short": "fix", "long": "Bug Fixes"},
+    {"short": "feat", "long": "Features"},
+    {"short": "imp", "long": "Improvements"}
+  ],
   "changelog_path": "CHANGELOG.md",
   "commit_message": "add changelog entry",
   "expected_spellings": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,12 @@ This changelog was created using the `clu` binary
 -->
 # Changelog
 
-## Unreleased
-
-### Improvements
-
-- (all) [#90](https://github.com/MalteHerrmann/changelog-utils/pull/90) Refactor fixed contents export for better maintainability.
-
 ## [v1.5.0](https://github.com/MalteHerrmann/changelog-utils/releases/tag/v1.5.0) - 2025-05-19
 
 ### Improvements
 
 - (cli) [#83](https://github.com/MalteHerrmann/changelog-utils/pull/83) Improve JSON parsing from LLM responses with regex extraction.
+- (all) [#90](https://github.com/MalteHerrmann/changelog-utils/pull/90) Refactor fixed contents export for better maintainability.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This changelog was created using the `clu` binary
 -->
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- (all) [#90](https://github.com/MalteHerrmann/changelog-utils/pull/90) Refactor fixed contents export for better maintainability.
+
 ## [v1.5.0](https://github.com/MalteHerrmann/changelog-utils/releases/tag/v1.5.0) - 2025-05-19
 
 ### Improvements

--- a/src/change_type.rs
+++ b/src/change_type.rs
@@ -10,6 +10,21 @@ pub struct ChangeType {
     pub entries: Vec<Entry>,
 }
 
+impl ChangeType {
+    pub fn get_fixed_contents(&self) -> String {
+        let mut exported_string = String::new();
+
+        exported_string.push_str(&self.fixed);
+        exported_string.push_str("\n\n");
+
+        self.entries.iter().for_each(|entry| {
+            exported_string.push_str(format!("{}\n", entry.fixed).as_str());
+        });
+
+        exported_string
+    }
+}
+
 // Creates a new instance of a change type.
 pub fn new(name: String, entries: Option<Vec<Entry>>) -> ChangeType {
     ChangeType {

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -38,19 +38,7 @@ impl Changelog {
 
         self.releases.iter().for_each(|release| {
             exported_string.push('\n');
-            exported_string.push_str(&release.fixed);
-            exported_string.push('\n');
-
-            release.change_types.iter().for_each(|change_type| {
-                exported_string.push('\n');
-                exported_string.push_str(&change_type.fixed);
-                exported_string.push_str("\n\n");
-
-                change_type.entries.iter().for_each(|entry| {
-                    exported_string.push_str(&entry.fixed);
-                    exported_string.push('\n');
-                });
-            });
+            exported_string.push_str(release.get_fixed_contents().as_str());
         });
 
         self.legacy_contents

--- a/src/release.rs
+++ b/src/release.rs
@@ -12,6 +12,20 @@ pub struct Release {
 }
 
 impl Release {
+    pub fn get_fixed_contents(&self) -> String {
+        let mut exported_string = String::new();
+
+        exported_string.push_str(&self.fixed);
+        exported_string.push('\n');
+
+        self.change_types.iter().for_each(|change_type| {
+            exported_string.push('\n');
+            exported_string.push_str(change_type.get_fixed_contents().as_str());
+        });
+
+        exported_string
+    }
+
     /// Returns a boolean value if the given release has the unreleased tag.
     pub fn is_unreleased(&self) -> bool {
         self.version == "Unreleased"


### PR DESCRIPTION
This PR refactors the export of fixed contents in the changelog library by adding dedicated methods to `ChangeType` and `Release` structures. These methods handle the export of their respective contents, making the code more modular and easier to maintain.

Main changes:
- Add `get_fixed_contents()` to `ChangeType` struct
- Add `get_fixed_contents()` to `Release` struct
- Simplify the export logic in the `Changelog` implementation

These changes improve code organization by encapsulating formatting logic within the relevant structures, following better object-oriented principles.