### PR TITLE
feat(cli): Add CLI command to get specific version release notes

### DIFF
--- a/.clconfig.json
+++ b/.clconfig.json
@@ -10,11 +10,11 @@
     "release",
     "test"
   ],
-  "change_types": {
-    "Bug Fixes": "fix",
-    "Features": "feat",
-    "Improvements": "imp"
-  },
+  "change_types": [
+    {"short": "feat", "long": "Features"},
+    {"short": "imp", "long": "Improvements"},
+    {"short": "fix", "long": "Bug Fixes"}
+  ],
   "changelog_path": "CHANGELOG.md",
   "commit_message": "add changelog entry",
   "expected_spellings": {

--- a/.clconfig.json
+++ b/.clconfig.json
@@ -10,11 +10,11 @@
     "release",
     "test"
   ],
-  "change_types": [
-    {"short": "feat", "long": "Features"},
-    {"short": "imp", "long": "Improvements"},
-    {"short": "fix", "long": "Bug Fixes"}
-  ],
+  "change_types": {
+    "Bug Fixes": "fix",
+    "Features": "feat",
+    "Improvements": "imp"
+  },
   "changelog_path": "CHANGELOG.md",
   "commit_message": "add changelog entry",
   "expected_spellings": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,12 @@ This changelog was created using the `clu` binary
 -->
 # Changelog
 
-## Unreleased
+## [v1.5.0](https://github.com/MalteHerrmann/changelog-utils/releases/tag/v1.5.0) - 2025-05-19
 
 ### Features
 
+- (cli) [#87](https://github.com/MalteHerrmann/changelog-utils/pull/87) Add version flag to CLI application.
 - (cli) [#91](https://github.com/MalteHerrmann/changelog-utils/pull/91) Add CLI command to get specific version release notes.
-
-## [v1.5.0](https://github.com/MalteHerrmann/changelog-utils/releases/tag/v1.5.0) - 2025-05-19
 
 ### Improvements
 
@@ -20,10 +19,6 @@ This changelog was created using the `clu` binary
 ### Bug Fixes
 
 - (cli) [#86](https://github.com/MalteHerrmann/changelog-utils/pull/86) Fix PR number insert when creating new PR.
-
-### Features
-
-- (cli) [#87](https://github.com/MalteHerrmann/changelog-utils/pull/87) Add version flag to CLI application.
 
 ## [v1.4.0](https://github.com/MalteHerrmann/changelog-utils/releases/tag/v1.4.0) - 2025-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This changelog was created using the `clu` binary
 -->
 # Changelog
 
+## Unreleased
+
+### Features
+
+- (cli) [#91](https://github.com/MalteHerrmann/changelog-utils/pull/91) Add CLI command to get specific version release notes.
+
 ## [v1.5.0](https://github.com/MalteHerrmann/changelog-utils/releases/tag/v1.5.0) - 2025-05-19
 
 ### Improvements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -903,9 +903,9 @@ checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -919,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
@@ -2485,15 +2485,15 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46ec44dc15085cea82cf9c78f85a9114c463a369786585ad2882d1ff0b0acf40"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
  "windows-result",
- "windows-strings 0.4.1",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -2537,9 +2537,9 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b895b5356fc36103d0f64dd1e94dfa7ac5633f1c9dd6e80fe9ec4adef69e09d"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
@@ -2555,9 +2555,9 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a7ab927b2637c19b3dbe0965e75d8f2d30bdd697a1516191cad2ec4df8fb28a"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,7 +11,9 @@ pub enum ChangelogCLI {
     CreatePR,
     #[command(about = "Applies all possible auto-fixes to the changelog")]
     Fix,
-    #[command(about = "Gets the contents of a specific version's release notes from the changelog")]
+    #[command(
+        about = "Gets the contents of a specific version's release notes from the changelog"
+    )]
     Get(GetArgs),
     #[command(about = "Checks if the changelog contents adhere to the defined rules")]
     Lint,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,6 +11,8 @@ pub enum ChangelogCLI {
     CreatePR,
     #[command(about = "Applies all possible auto-fixes to the changelog")]
     Fix,
+    #[command(about = "Gets the contents of a specific version's release notes from the changelog")]
+    Get(GetArgs),
     #[command(about = "Checks if the changelog contents adhere to the defined rules")]
     Lint,
     #[command(about = "Initializes the changelog configuration in the current directory")]
@@ -33,6 +35,11 @@ pub struct AddArgs {
     pub number: Option<u16>,
     #[arg(short, long)]
     pub yes: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct GetArgs {
+    pub version: String,
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/create_pr.rs
+++ b/src/create_pr.rs
@@ -60,8 +60,11 @@ pub async fn run() -> Result<(), CreateError> {
             .html_url
             .expect("received no error creating the PR but html_url was None")
     );
-    
-    let pr_number: u16 = created_pr.number.try_into().map_err(CreateError::OutOfRange)?;
+
+    let pr_number: u16 = created_pr
+        .number
+        .try_into()
+        .map_err(CreateError::OutOfRange)?;
 
     let mut changelog = changelog::load(config.clone())?;
     add::add_entry(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,6 +12,8 @@ pub enum CLIError {
     AddError(#[from] AddError),
     #[error("failed to create pr: {0}")]
     CreateError(#[from] CreateError),
+    #[error("failed to get release contents: {0}")]
+    GetError(#[from] GetError),
     #[error("failed to initialize the changelog settings: {0}")]
     InitError(#[from] InitError),
     #[error("failed to run linter: {0}")]
@@ -124,6 +126,16 @@ pub enum ChangelogError {
 pub enum EntryError {
     #[error("invalid entry: {0}")]
     InvalidEntry(String),
+}
+
+#[derive(Error, Debug)]
+pub enum GetError {
+    #[error("failed to get config: {0}")]
+    Config(#[from] ConfigError),
+    #[error("failed to get changelog: {0}")]
+    Changelog(#[from] ChangelogError),
+    #[error("version not found: {0}")]
+    VersionNotFound(String),
 }
 
 #[derive(Error, Debug)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,8 +2,8 @@ use inquire::InquireError;
 use regex::Error;
 use rig::completion::PromptError;
 use serde_json;
-use std::{env::VarError, io, num::ParseIntError, string::FromUtf8Error};
 use std::num::TryFromIntError;
+use std::{env::VarError, io, num::ParseIntError, string::FromUtf8Error};
 use thiserror::Error;
 
 #[derive(Error, Debug)]

--- a/src/get.rs
+++ b/src/get.rs
@@ -1,4 +1,4 @@
-use crate::{changelog, config, errors::GetError, cli::GetArgs};
+use crate::{changelog, cli::GetArgs, config, errors::GetError};
 
 /// Executes the get command to display a specific version's release notes.
 pub fn run(args: GetArgs) -> Result<(), GetError> {
@@ -14,9 +14,11 @@ pub fn run(args: GetArgs) -> Result<(), GetError> {
 }
 
 fn get(changelog: &changelog::Changelog, args: &GetArgs) -> Result<(), GetError> {
-    if let Some(release) = changelog.releases.iter().find(|r| {
-        r.version == args.version
-    }) {
+    if let Some(release) = changelog
+        .releases
+        .iter()
+        .find(|r| r.version == args.version)
+    {
         println!("{}", release.get_fixed_contents());
         return Ok(());
     }
@@ -32,8 +34,10 @@ mod tests {
 
     /// Creates a test config from the example config file
     fn load_test_config() -> config::Config {
-        config::unpack_config(include_str!("testdata/example_config_without_optionals.json"))
-            .expect("failed to load example config")
+        config::unpack_config(include_str!(
+            "testdata/example_config_without_optionals.json"
+        ))
+        .expect("failed to load example config")
     }
 
     /// Test that we can successfully find an existing version
@@ -41,60 +45,70 @@ mod tests {
     fn test_get_existing_version() {
         // Load the test config
         let config = load_test_config();
-        
+
         // Parse the actual changelog from this repo
         let changelog_path = Path::new("CHANGELOG.md");
         if !changelog_path.exists() {
             // Skip test if changelog doesn't exist
             return;
         }
-        
+
         let changelog = match changelog::parse_changelog(config, changelog_path) {
             Ok(cl) => cl,
             Err(ChangelogError::NoChangelogFound) => {
                 // Skip test if changelog not found
                 return;
-            },
+            }
             Err(e) => panic!("Failed to parse changelog: {:?}", e),
         };
-        
+
         // The v1.0.0 version should exist in the changelog
-        let result = get(&changelog, &GetArgs { version: "v1.0.0".to_string() });
+        let result = get(
+            &changelog,
+            &GetArgs {
+                version: "v1.0.0".to_string(),
+            },
+        );
         assert!(result.is_ok());
     }
-    
+
     /// Test handling of a non-existent version
     #[test]
     fn test_get_nonexistent_version() {
         // Load the test config
         let config = load_test_config();
-        
+
         // Parse the actual changelog from this repo
         let changelog_path = Path::new("CHANGELOG.md");
         if !changelog_path.exists() {
             // Skip test if changelog doesn't exist
             return;
         }
-        
+
         let changelog = match changelog::parse_changelog(config, changelog_path) {
             Ok(cl) => cl,
             Err(ChangelogError::NoChangelogFound) => {
                 // Skip test if changelog not found
                 return;
-            },
+            }
             Err(e) => panic!("Failed to parse changelog: {:?}", e),
         };
-        
+
         // A version that definitely doesn't exist
-        let result = get(&changelog, &GetArgs { version: "v999.999.999".to_string() });
+        let result = get(
+            &changelog,
+            &GetArgs {
+                version: "v999.999.999".to_string(),
+            },
+        );
         assert!(result.is_err());
-        
+
         // Check specific error type
         match result {
             Err(GetError::VersionNotFound(version)) => {
                 assert_eq!(version, "v999.999.999");
-            },
+            }
             _ => panic!("Expected VersionNotFound error"),
         }
     }
-} 
+}

--- a/src/get.rs
+++ b/src/get.rs
@@ -1,0 +1,122 @@
+use crate::{changelog, config, errors::GetError, cli::GetArgs};
+
+/// Executes the get command to display a specific version's release notes.
+pub fn run(args: GetArgs) -> Result<(), GetError> {
+    let config = config::load()?;
+    let changelog = changelog::load(config)?;
+
+    match get(&changelog, &args) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            eprintln!("Version {} not found in changelog: {}", args.version, e);
+            Err(e)
+        }
+    }
+}
+
+fn get(changelog: &changelog::Changelog, args: &GetArgs) -> Result<(), GetError> {
+    let release = changelog.releases.iter().find(|r| {
+        println!("checking {} against {}", r.version, args.version);
+        r.version == args.version
+    });
+    
+    match release {
+        Some(release) => {
+            // Print the release header
+            //
+            // TODO: add a method to the release struct to print the contents
+            println!("{}", release.fixed);
+            println!();
+
+            // Print each change type and its entries
+            for change_type in &release.change_types {
+                println!("{}", change_type.fixed);
+                println!();
+                
+                for entry in &change_type.entries {
+                    println!("{}", entry.fixed);
+                }
+                println!();
+            }
+            Ok(())
+        },
+        None => {
+            Err(GetError::VersionNotFound(args.version.clone()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::errors::ChangelogError;
+    use std::path::Path;
+
+    /// Creates a test config from the example config file
+    fn load_test_config() -> config::Config {
+        config::unpack_config(include_str!("testdata/example_config.json"))
+            .expect("failed to load example config")
+    }
+
+    /// Test that we can successfully find an existing version
+    #[test]
+    fn test_get_existing_version() {
+        // Load the test config
+        let config = load_test_config();
+        
+        // Parse the actual changelog from this repo
+        let changelog_path = Path::new("CHANGELOG.md");
+        if !changelog_path.exists() {
+            // Skip test if changelog doesn't exist
+            return;
+        }
+        
+        let changelog = match changelog::parse_changelog(config, changelog_path) {
+            Ok(cl) => cl,
+            Err(ChangelogError::NoChangelogFound) => {
+                // Skip test if changelog not found
+                return;
+            },
+            Err(e) => panic!("Failed to parse changelog: {:?}", e),
+        };
+        
+        // The v1.0.0 version should exist in the changelog
+        let result = get(&changelog, &GetArgs { version: "v1.0.0".to_string() });
+        assert!(result.is_ok());
+    }
+    
+    /// Test handling of a non-existent version
+    #[test]
+    fn test_get_nonexistent_version() {
+        // Load the test config
+        let config = load_test_config();
+        
+        // Parse the actual changelog from this repo
+        let changelog_path = Path::new("CHANGELOG.md");
+        if !changelog_path.exists() {
+            // Skip test if changelog doesn't exist
+            return;
+        }
+        
+        let changelog = match changelog::parse_changelog(config, changelog_path) {
+            Ok(cl) => cl,
+            Err(ChangelogError::NoChangelogFound) => {
+                // Skip test if changelog not found
+                return;
+            },
+            Err(e) => panic!("Failed to parse changelog: {:?}", e),
+        };
+        
+        // A version that definitely doesn't exist
+        let result = get(&changelog, &GetArgs { version: "v999.999.999".to_string() });
+        assert!(result.is_err());
+        
+        // Check specific error type
+        match result {
+            Err(GetError::VersionNotFound(version)) => {
+                assert_eq!(version, "v999.999.999");
+            },
+            _ => panic!("Expected VersionNotFound error"),
+        }
+    }
+} 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod diff_prompt;
 mod entry;
 pub mod errors;
 mod escapes;
+pub mod get;
 pub mod github;
 pub mod init;
 mod inputs;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ Main file to run the changelog utils application.
 */
 use clap::Parser;
 use clu::{
-    add, cli::ChangelogCLI, cli_config, create_pr, errors::CLIError, init, lint, release_cli,
+    add, cli::ChangelogCLI, cli_config, create_pr, errors::CLIError, get, init, lint, release_cli,
 };
 
 #[tokio::main]
@@ -12,6 +12,7 @@ async fn main() -> Result<(), CLIError> {
         ChangelogCLI::Add(add_args) => Ok(add::run(add_args.number, add_args.yes).await?),
         ChangelogCLI::CreatePR => Ok(create_pr::run().await?),
         ChangelogCLI::Fix => Ok(lint::run(true)?),
+        ChangelogCLI::Get(get_args) => Ok(get::run(get_args)?),
         ChangelogCLI::Lint => Ok(lint::run(false)?),
         ChangelogCLI::Init => Ok(init::run()?),
         ChangelogCLI::Config(config_subcommand) => {


### PR DESCRIPTION
This PR adds a new 'get' command to the CLI that allows users to retrieve the release notes for a specific version from the changelog.

Key changes:
- Added new `Get` command to the CLI interface with a required version argument
- Implemented `get.rs` module with functionality to find and display release notes
- Updated error handling to handle version not found cases
- Added unit tests for the new functionality
- Refactored change_types in config from object to array format