### PR TITLE
imp(cli): Add check for empty diffs when creating PRs

### DIFF
--- a/src/create_pr.rs
+++ b/src/create_pr.rs
@@ -29,6 +29,11 @@ pub async fn run() -> Result<(), CreateError> {
         .await?;
 
     let target = inputs::get_target_branch(branches)?;
+    
+    let diff = github::get_diff(&git_info.branch, &target)?;
+    if diff.trim().is_empty() {
+        return Err(CreateError::EmptyDiff(git_info.branch.clone(), target.clone()));
+    }
 
     let use_ai = inputs::get_use_ai()?;
     let mut suggestions = diff_prompt::Suggestions::default();

--- a/src/create_pr.rs
+++ b/src/create_pr.rs
@@ -35,6 +35,9 @@ pub async fn run() -> Result<(), CreateError> {
     if use_ai {
         match diff_prompt::get_suggestions(&config, &git_info.branch, &target).await {
             Ok(s) => suggestions = s,
+            // NOTE: in case of an empty diff between branches we just return the error as there is no PR to be created
+            Err(CreateError::EmptyDiff(a, b)) => return Err(CreateError::EmptyDiff(a, b)),
+            // NOTE: in case of any other error we just print the decoding error here and continue with defaults
             Err(_) => println!("failed to decode llm response"),
         };
     }

--- a/src/diff_prompt.rs
+++ b/src/diff_prompt.rs
@@ -12,6 +12,10 @@ pub async fn get_suggestions(
     pr_target: &str,
 ) -> Result<Suggestions, CreateError> {
     let diff = github::get_diff(work_branch, pr_target)?;
+    if diff.trim().is_empty() {
+        return Err(CreateError::EmptyDiff(work_branch.into(), pr_target.into()))
+    }
+    
     let response = prompt(config, diff.as_str()).await?;
 
     parse_suggestions(&response)

--- a/src/diff_prompt.rs
+++ b/src/diff_prompt.rs
@@ -6,6 +6,7 @@ use rig::{
 };
 use serde::Deserialize;
 
+// TODO: might make sense to refactor this to just take in the diff instead of getting the diff manually as well
 pub async fn get_suggestions(
     config: &Config,
     work_branch: &str,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -36,6 +36,8 @@ pub enum CreateError {
     Changelog(#[from] ChangelogError),
     #[error("failed to read configuration: {0}")]
     Config(#[from] ConfigError),
+    #[error("empty diff found between '{0}' and '{1}'")]
+    EmptyDiff(String, String),
     #[error("found an existing PR for this branch: {0}")]
     ExistingPR(u64),
     #[error("failed to create PR: {0}")]


### PR DESCRIPTION
This PR enhances the PR creation workflow by adding validation for empty diffs between branches.

Key changes:
- Added a new `EmptyDiff` error type to handle cases where there are no differences between branches
- Implemented checks in both the main PR creation flow and diff prompt handling to detect empty diffs early
- Added proper error handling to prevent attempting to create PRs when no changes exist

The most significant changes are in `create_pr.rs`, `diff_prompt.rs`, and `errors.rs`.