### PR TITLE
imp(cli): Fail PR creation when having problems parsing the LLM response

### DIFF
--- a/src/create_pr.rs
+++ b/src/create_pr.rs
@@ -38,11 +38,7 @@ pub async fn run() -> Result<(), CreateError> {
     let use_ai = inputs::get_use_ai()?;
     let mut suggestions = diff_prompt::Suggestions::default();
     if use_ai {
-        match diff_prompt::get_suggestions(&config, &diff).await {
-            Ok(s) => suggestions = s,
-            // NOTE: in case of any other error we just print the decoding error here and continue with defaults
-            Err(e) => println!("failed to decode llm response: {e}"),
-        };
+        suggestions = diff_prompt::get_suggestions(&config, &diff).await?;
     }
 
     let change_type = inputs::get_change_type(&config, &suggestions.change_type)?;


### PR DESCRIPTION
This PR improves the error handling in the PR creation flow when using AI suggestions. Instead of silently continuing with defaults when the LLM response fails, we now properly propagate the error to the caller.

Changes:
- Modified `create_pr.rs` to properly propagate errors from `diff_prompt::get_suggestions` instead of catching and printing them locally