### PR TITLE
imp(cli): Refactor Git operations into dedicated module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog was created using the `clu` binary
 
 ### Improvements
 
+- (cli) [#97](https://github.com/MalteHerrmann/changelog-utils/pull/97) Refactor Git operations into dedicated module.
 - (cli) [#94](https://github.com/MalteHerrmann/changelog-utils/pull/94) Fail PR creation when having problems parsing the LLM response.
 - (cli) [#93](https://github.com/MalteHerrmann/changelog-utils/pull/93) Add check for empty diffs when creating PRs.
 - (ci) [#92](https://github.com/MalteHerrmann/changelog-utils/pull/92) Update changelog lint action to v0.3.0 and adjust config.

--- a/src/add.rs
+++ b/src/add.rs
@@ -1,7 +1,8 @@
 use crate::{
     change_type, changelog, config, entry,
     errors::AddError,
-    github::{commit, get_git_info, get_pr_info, PRInfo},
+    git::{commit, get_git_info},
+    github::{get_pr_info, PRInfo},
     inputs, release,
 };
 use std::collections::HashMap;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -44,6 +44,8 @@ pub enum CreateError {
     FailedToMatch(String),
     #[error("failed to parse llm suggestions: {0}")]
     FailedToParse(#[from] serde_json::Error),
+    #[error("error interacting with Git: {0}")]
+    Git(#[from] GitError),
     #[error("error interacting with GitHub: {0}")]
     GitHub(#[from] GitHubError),
     #[error("error getting user input: {0}")]
@@ -72,6 +74,8 @@ pub enum AddError {
     Input(#[from] InputError),
     #[error("first release is not unreleased section: {0}")]
     FirstReleaseNotUnreleased(String),
+    #[error("failed to get git information: {0}")]
+    Git(#[from] GitError),
     #[error("failed to get pull request information: {0}")]
     PRInfo(#[from] GitHubError),
     #[error("failed to parse changelog: {0}")]
@@ -89,7 +93,7 @@ pub enum InitError {
     #[error("error exporting config: {0}")]
     ConfigError(#[from] ConfigError),
     #[error("failed to get origin")]
-    OriginError(#[from] GitHubError),
+    OriginError(#[from] GitError),
 }
 
 #[derive(Error, Debug)]
@@ -139,7 +143,7 @@ pub enum GetError {
 }
 
 #[derive(Error, Debug)]
-pub enum GitHubError {
+pub enum GitError {
     #[error("failed to get current branch")]
     CurrentBranch,
     #[error("failed to get diff")]
@@ -150,14 +154,8 @@ pub enum GitHubError {
     FailedToCommit,
     #[error("failed to push to origin")]
     FailedToPush,
-    #[error("failed to call GitHub API: {0}")]
-    GitHub(#[from] octocrab::Error),
     #[error("failed to build regex: {0}")]
     InvalidRegex(#[from] Error),
-    #[error("target repository in configuration is no GitHub repository")]
-    NoGitHubRepo,
-    #[error("no pull request open for branch")]
-    NoOpenPR,
     #[error("failed to get origin")]
     Origin,
     #[error("failed to decode output: {0}")]
@@ -166,6 +164,20 @@ pub enum GitHubError {
     RegexMatch(String),
     #[error("failed to execute command: {0}")]
     StdCommand(#[from] io::Error),
+}
+
+#[derive(Error, Debug)]
+pub enum GitHubError {
+    #[error("failed to call GitHub API: {0}")]
+    GitHub(#[from] octocrab::Error),
+    #[error("failed to build regex: {0}")]
+    InvalidRegex(#[from] Error),
+    #[error("target repository in configuration is no GitHub repository")]
+    NoGitHubRepo,
+    #[error("no pull request open for branch")]
+    NoOpenPR,
+    #[error("failed to decode output: {0}")]
+    OutputDecoding(#[from] FromUtf8Error),
     #[error("GITHUB_TOKEN environment variable not found")]
     Token(#[from] VarError),
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,0 +1,172 @@
+use crate::config::Config;
+use crate::errors::GitError;
+use regex::Regex;
+use std::process::Command;
+
+/// Retrieves the name of the current branch if the working directory
+/// is a Git repository.
+pub fn get_current_local_branch() -> Result<String, GitError> {
+    let output = Command::new("git")
+        .args(vec!["branch", "--show-current"])
+        .output()?;
+
+    match output.status.success() {
+        true => Ok(String::from_utf8(output.stdout)?.trim().to_string()),
+        false => Err(GitError::CurrentBranch),
+    }
+}
+
+/// Commits the current changes with the given commit message and pushes to the origin.
+pub fn commit_and_push(config: &Config, message: &str) -> Result<(), GitError> {
+    stage_changelog_changes(config)?;
+
+    match Command::new("git")
+        .args(vec!["commit", "-a", "-m", message])
+        .status()?
+        .success()
+    {
+        true => Ok(push()?),
+        false => Err(GitError::FailedToCommit),
+    }
+}
+
+/// Commits the current changes with the given commit message.
+pub fn commit(config: &Config, message: &str) -> Result<(), GitError> {
+    stage_changelog_changes(config)?;
+
+    if !Command::new("git")
+        .args(vec!["commit", "-m", message])
+        .status()?
+        .success()
+    {
+        return Err(GitError::FailedToCommit);
+    }
+
+    Ok(())
+}
+
+/// Gets the diff between the two defined branches.
+pub fn get_diff(branch: &str, target: &str) -> Result<String, GitError> {
+    let diff_str = format!("{}...{}", target, branch);
+    let out = Command::new("git")
+        .args(vec!["diff", diff_str.as_str()])
+        .output()?;
+
+    if !out.status.success() {
+        return Err(GitError::Diff);
+    }
+
+    let diff = String::from_utf8(out.stdout)?;
+    let diff_trimmed = diff.trim();
+    match diff_trimmed.is_empty() {
+        true => Err(GitError::EmptyDiff(branch.into(), target.into())),
+        false => Ok(diff_trimmed.into()),
+    }
+}
+
+/// Adds the changelog to the staged changes in Git.
+fn stage_changelog_changes(config: &Config) -> Result<(), GitError> {
+    if !Command::new("git")
+        .args(vec!["add", config.changelog_path.as_str()])
+        .status()?
+        .success()
+    {
+        return Err(GitError::FailedToCommit);
+    }
+
+    Ok(())
+}
+
+/// Tries to push the latest commits on the current branch.
+pub fn push() -> Result<(), GitError> {
+    match Command::new("git").args(vec!["push"]).status()?.success() {
+        true => Ok(()),
+        false => Err(GitError::FailedToPush),
+    }
+}
+
+/// Tries to push the current branch to the origin repository.
+pub fn push_to_origin(branch_name: &str) -> Result<(), GitError> {
+    match Command::new("git")
+        .args(vec!["push", "-u", "origin", branch_name])
+        .status()?
+        .success()
+    {
+        true => Ok(()),
+        false => Err(GitError::FailedToPush),
+    }
+}
+
+/// Checks if there is a origin repository defined and returns the name
+/// if that's the case.
+pub fn get_origin() -> Result<String, GitError> {
+    let output = Command::new("git")
+        .args(vec!["remote", "get-url", "origin"])
+        .output()?;
+
+    if !output.status.success() {
+        return Err(GitError::Origin);
+    };
+
+    let origin = String::from_utf8(output.stdout)?;
+    match Regex::new(r"(https://github.com/[^.\s]+/[^.\s]+)(\.git)?")?.captures(origin.as_str()) {
+        Some(o) => Ok(o
+            .get(1)
+            .expect("unexpected matching condition")
+            .as_str()
+            .to_string()),
+        None => Err(GitError::RegexMatch(origin)),
+    }
+}
+
+/// Holds the relevant information for the Git configuration.
+#[derive(Clone)]
+pub struct GitInfo {
+    pub owner: String,
+    pub repo: String,
+    pub branch: String,
+}
+
+/// Retrieves the Git information like the currently checked out branch and
+/// repository owner and name.
+pub fn get_git_info(config: &Config) -> Result<GitInfo, GitError> {
+    let captures = match Regex::new(r"github.com/(?P<owner>[\w-]+)/(?P<repo>[\w-]+)\.*")
+        .expect("failed to build regular expression")
+        .captures(config.target_repo.as_str())
+    {
+        Some(r) => r,
+        None => return Err(GitError::RegexMatch(config.target_repo.clone())),
+    };
+
+    let owner = captures.name("owner").unwrap().as_str().to_string();
+    let repo = captures.name("repo").unwrap().as_str().to_string();
+    let branch = get_current_local_branch()?;
+
+    Ok(GitInfo {
+        owner,
+        repo,
+        branch,
+    })
+}
+
+// Ignore these tests when running on CI because there won't be a local branch
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(not(feature = "remote"))]
+    #[test]
+    fn test_current_branch() {
+        let branch = get_current_local_branch().expect("failed to get current branch");
+        assert_ne!(branch, "", "expected non-empty current branch")
+    }
+
+    #[test]
+    fn test_get_origin() {
+        let origin = get_origin().expect("failed to get origin");
+        assert_eq!(
+            origin, "https://github.com/MalteHerrmann/changelog-utils",
+            "expected different origin"
+        )
+    }
+}

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,11 +1,11 @@
 use crate::entry::check_category;
 use crate::errors::GitHubError;
+use crate::git::GitInfo;
 use crate::{config::Config, entry::check_description};
 use octocrab::models::pulls::PullRequest;
 use octocrab::params::repos::Reference::Branch;
 use octocrab::{self, Octocrab};
-use regex::{Regex, RegexBuilder};
-use std::process::Command;
+use regex::RegexBuilder;
 
 /// Holds the relevant information for a given PR.
 #[derive(Default)]
@@ -101,152 +101,6 @@ pub async fn get_open_pr(git_info: GitInfo) -> Result<PullRequest, GitHubError> 
     }
 }
 
-/// Retrieves the name of the current branch if the working directory
-/// is a Git repository.
-fn get_current_local_branch() -> Result<String, GitHubError> {
-    let output = Command::new("git")
-        .args(vec!["branch", "--show-current"])
-        .output()?;
-
-    match output.status.success() {
-        true => Ok(String::from_utf8(output.stdout)?.trim().to_string()),
-        false => Err(GitHubError::CurrentBranch),
-    }
-}
-
-/// Commits the current changes with the given commit message and pushes to the origin.
-pub fn commit_and_push(config: &Config, message: &str) -> Result<(), GitHubError> {
-    stage_changelog_changes(config)?;
-
-    match Command::new("git")
-        .args(vec!["commit", "-a", "-m", message])
-        .status()?
-        .success()
-    {
-        true => Ok(push()?),
-        false => Err(GitHubError::FailedToCommit),
-    }
-}
-
-/// Commits the current changes with the given commit message and pushes to the origin.
-pub fn commit(config: &Config, message: &str) -> Result<(), GitHubError> {
-    stage_changelog_changes(config)?;
-
-    if !Command::new("git")
-        .args(vec!["commit", "-m", message])
-        .status()?
-        .success()
-    {
-        return Err(GitHubError::FailedToCommit);
-    }
-
-    Ok(())
-}
-
-/// Gets the diff between the two defined branches.
-pub fn get_diff(branch: &str, target: &str) -> Result<String, GitHubError> {
-    let diff_str = format!("{}...{}", target, branch);
-    let out = Command::new("git")
-        .args(vec!["diff", diff_str.as_str()])
-        .output()?;
-
-    if !out.status.success() {
-        return Err(GitHubError::Diff);
-    }
-
-    let diff = String::from_utf8(out.stdout)?;
-    let diff_trimmed = diff.trim();
-    match diff_trimmed.is_empty() {
-        true => Err(GitHubError::EmptyDiff(branch.into(), target.into())),
-        false => Ok(diff_trimmed.into()),
-    }
-}
-
-/// Adds the changelog to the staged changes in Git.
-fn stage_changelog_changes(config: &Config) -> Result<(), GitHubError> {
-    if !Command::new("git")
-        .args(vec!["add", config.changelog_path.as_str()])
-        .status()?
-        .success()
-    {
-        return Err(GitHubError::FailedToCommit);
-    }
-
-    Ok(())
-}
-
-/// Tries to push the latest commits on the current branch.
-pub fn push() -> Result<(), GitHubError> {
-    match Command::new("git").args(vec!["push"]).status()?.success() {
-        true => Ok(()),
-        false => Err(GitHubError::FailedToPush),
-    }
-}
-
-/// Tries to push the current branch to the origin repository.
-pub fn push_to_origin(branch_name: &str) -> Result<(), GitHubError> {
-    match Command::new("git")
-        .args(vec!["push", "-u", "origin", branch_name])
-        .status()?
-        .success()
-    {
-        true => Ok(()),
-        false => Err(GitHubError::FailedToPush),
-    }
-}
-
-/// Checks if there is a origin repository defined and returns the name
-/// if that's the case.
-pub fn get_origin() -> Result<String, GitHubError> {
-    let output = Command::new("git")
-        .args(vec!["remote", "get-url", "origin"])
-        .output()?;
-
-    if !output.status.success() {
-        return Err(GitHubError::Origin);
-    };
-
-    let origin = String::from_utf8(output.stdout)?;
-    match Regex::new(r"(https://github.com/[^.\s]+/[^.\s]+)(\.git)?")?.captures(origin.as_str()) {
-        Some(o) => Ok(o
-            .get(1)
-            .expect("unexpected matching condition")
-            .as_str()
-            .to_string()),
-        None => Err(GitHubError::RegexMatch(origin)),
-    }
-}
-
-/// Holds the relevant information for the Git configuration.
-#[derive(Clone)]
-pub struct GitInfo {
-    pub owner: String,
-    pub repo: String,
-    pub branch: String,
-}
-
-/// Retrieves the Git information like the currently checked out branch and
-/// repository owner and name.
-pub fn get_git_info(config: &Config) -> Result<GitInfo, GitHubError> {
-    let captures = match Regex::new(r"github.com/(?P<owner>[\w-]+)/(?P<repo>[\w-]+)\.*")
-        .expect("failed to build regular expression")
-        .captures(config.target_repo.as_str())
-    {
-        Some(r) => r,
-        None => return Err(GitHubError::NoGitHubRepo),
-    };
-
-    let owner = captures.name("owner").unwrap().as_str().to_string();
-    let repo = captures.name("repo").unwrap().as_str().to_string();
-    let branch = get_current_local_branch()?;
-
-    Ok(GitInfo {
-        owner,
-        repo,
-        branch,
-    })
-}
-
 /// Returns a PR from the repository by its number.
 async fn get_pr_by_number(git_info: &GitInfo, pr_number: u16) -> Result<PullRequest, GitHubError> {
     let client = get_authenticated_github_client()?;
@@ -276,26 +130,4 @@ pub async fn get_pr_info(
     }
 
     Ok(PRInfo::default())
-}
-
-// Ignore these tests when running on CI because there won't be a local branch
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[cfg(not(feature = "remote"))]
-    #[test]
-    fn test_current_branch() {
-        let branch = get_current_local_branch().expect("failed to get current branch");
-        assert_ne!(branch, "", "expected non-empty current branch")
-    }
-
-    #[test]
-    fn test_get_origin() {
-        let origin = get_origin().expect("failed to get origin");
-        assert_eq!(
-            origin, "https://github.com/MalteHerrmann/changelog-utils",
-            "expected different origin"
-        )
-    }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,6 +1,6 @@
 use crate::{
     changelog::get_settings_from_existing_changelog, config::Config, errors::InitError,
-    github::get_origin,
+    git::get_origin,
 };
 use std::{fs, path::PathBuf};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod entry;
 pub mod errors;
 mod escapes;
 pub mod get;
+pub mod git;
 pub mod github;
 pub mod init;
 mod inputs;


### PR DESCRIPTION
This PR splits Git-related operations from GitHub API interactions by moving Git functionality into a new `git.rs` module. This separation improves code organization, making it easier to maintain and extend both Git and GitHub functionality independently.

Main changes:
- Created a new `git.rs` module for all Git command operations
- Moved Git-related functionality from `github.rs` to `git.rs`
- Updated error handling with a dedicated `GitError` type
- Updated imports and function calls throughout the codebase
- Preserved the tests for Git operations