### PR TITLE
imp(ci): Add makefile target for tests run in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,6 @@ jobs:
       - run: cargo build --verbose --locked
 
       # Run tests
-      - run: cargo nextest run --verbose --features remote --profile CI
+      - run: make test-ci
         env:
           CARGO_TERM_COLOR: always

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 # Run tests
+.PHONY: test test-ci
 test:
 	cargo nextest run
+
+test-ci:
+	cargo nextest run --verbose --profile CI --features remote
 
 # Build binary locally
 build:
@@ -26,4 +30,4 @@ docker-build:
 lint:
 	cargo clippy
 
-PHONY: test build format install docker-run docker-build lint
+PHONY: build format install docker-run docker-build lint

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ in existing projects. In that case, it will only create the default configuratio
 
 ## Configuration
 
+<!-- TODO: update this for recent changes -->
 You can add or remove configurations as you like with the
 corresponding subcommands of `clu config`.
 


### PR DESCRIPTION
This PR just adds a Makefile target to make it easier to run the exact same tests as in CI locally.
